### PR TITLE
feat: dep-checkスキルのname・description・出力テンプレートを改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ allowed-tools:
 | Issue管理 | `refine-issue` |
 | 開発ループ | `dev-loop` |
 | PR・レビュー | `pr-comment` |
-| 依存関係 | `dep-check` |
+| 依存関係 | `dependency-check` |
 
 ### DoR Framework
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cp skills/refine-issue/references/dor-default.md /path/to/your-project/.claude/d
 
 | スキル | コマンド | 説明 |
 |---|---|---|
-| dep-check | `/dep-check react` | 依存パッケージ更新のBreaking Changes・互換性・コード影響を自動分析 |
+| dependency-check | `/dependency-check react` | 依存パッケージ更新のBreaking Changes・互換性・コード影響を自動分析 |
 
 ## カスタマイズポイント
 

--- a/skills/dependency-check/SKILL.md
+++ b/skills/dependency-check/SKILL.md
@@ -1,11 +1,10 @@
 ---
-description: 依存パッケージ更新のBreaking Changes・互換性・コード影響を自動分析する
+description: 依存パッケージ更新のBreaking Changes・互換性・コード影響を自動分析する。パッケージのバージョンを上げたい・更新影響を調べたい・アップデートのリスクを知りたいときに使用
 allowed-tools:
   - Read
   - Grep
   - Glob
   - WebFetch
-  - AskUserQuestion
 ---
 
 # 依存パッケージ更新 影響分析パイプライン
@@ -37,7 +36,7 @@ PM別コマンド対応表:
 | レジストリ情報取得 | `npm info {pkg}` | `pnpm info {pkg}` | `yarn npm info {pkg}` | `npm info {pkg}` |
 | 依存元特定 | `npm explain {pkg}` | `pnpm why {pkg}` | `yarn why {pkg}` | `bun pm ls` |
 
-検出できない場合はAskUserQuestionでユーザーに確認する。
+検出できない場合はエラーメッセージを出力して終了する。
 
 ### Phase 1: バージョン解決
 
@@ -83,7 +82,7 @@ PM別コマンド対応表:
 以下の形式で分析結果を提示する。該当しないセクションは省略してよい。
 
 ```markdown
-## dep-check: {パッケージ名}
+## {パッケージ名}
 
 | 項目 | 結果 |
 |---|---|


### PR DESCRIPTION
## Summary

- `dep-check` → `dependency-check` にスキルディレクトリ名をリネーム
- `description` に「いつ使うか」のトリガー情報を追加
- `AskUserQuestion` を `allowed-tools` から削除し、PM検出失敗時はエラー終了に変更
- 出力テンプレート見出しからスキル名（`dep-check:`）を削除
- CLAUDE.md・README.md のスキル一覧テーブルを更新

## セルフレビュー実施済み

レビュー: 1周実施、指摘0件

## Test plan

- [x] `setup-local.sh` 実行後、`.claude/skills/dependency-check` シンボリックリンクが存在しSKILL.mdを参照
- [x] `.claude/skills/dep-check` が存在しない（旧リンク削除済み）
- [x] `scripts/validate-skills.sh` が正常終了

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)