### PR TITLE
feat: スキルリンクの整合性チェックスクリプトを追加

### DIFF
--- a/scripts/check-skill-links.sh
+++ b/scripts/check-skill-links.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # .claude/skills/ のシンボリックリンクの整合性をチェックするスクリプト
-
-cd /home/kuchita/Development/claude-shared-skills
+set -euo pipefail
+cd "$(dirname "$0")/.."
 
 count=0
 broken=0
@@ -24,4 +24,5 @@ echo "チェック完了: $count リンク中 $broken 件が壊れています"
 
 if [ $broken -gt 0 ]; then
   echo "壊れたリンクを修復するには ./setup-local.sh を実行してください"
+  exit 1
 fi


### PR DESCRIPTION
## 概要
`.claude/skills/` のシンボリックリンクの整合性をチェックするスクリプトを追加。

## 変更内容
- `scripts/check-skill-links.sh` を新規追加
- 壊れたリンクの検出と報告機能