### PR TITLE
feat: setup-local.shに--dry-runオプションを追加

### DIFF
--- a/setup-local.sh
+++ b/setup-local.sh
@@ -3,12 +3,30 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-mkdir -p .claude/skills
+# --dry-run オプションの解析
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+  esac
+done
+
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] Would create directory: .claude/skills"
+else
+  mkdir -p .claude/skills
+fi
 
 # 壊れたシンボリックリンクを削除
 for link in .claude/skills/*; do
   if [ -L "$link" ] && [ ! -e "$link" ]; then
-    rm "$link"
+    if [ "$DRY_RUN" = true ]; then
+      echo "[DRY RUN] Would remove broken link: $link"
+    else
+      rm "$link"
+    fi
   fi
 done
 
@@ -16,10 +34,22 @@ done
 for dir in skills/*/; do
   name=$(basename "$dir")
   target=".claude/skills/$name"
-  if [ ! -e "$target" ]; then
-    ln -s "../../skills/$name" "$target"
+  if [ "$DRY_RUN" = true ]; then
+    if [ ! -e "$target" ]; then
+      echo "[DRY RUN] Would create link: $target -> ../../skills/$name"
+    else
+      echo "[DRY RUN] Already exists, skip: $target"
+    fi
+  else
+    if [ ! -e "$target" ]; then
+      ln -s "../../skills/$name" "$target"
+    fi
   fi
 done
 
-echo "Done. Linked skills:"
-ls -la .claude/skills/
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] No changes were made."
+else
+  echo "Done. Linked skills:"
+  ls -la .claude/skills/
+fi


### PR DESCRIPTION
## 概要

setup-local.shに`--dry-run`オプションを追加し、実行前に何が行われるかを確認できるようにした。

Closes #42

## 変更内容

- `--dry-run`フラグの引数パースを追加
- ディレクトリ作成、壊れたリンク削除、リンク作成の全操作をdry-run対応
- dry-run時は`[DRY RUN]`プレフィックス付きで操作内容を表示し、ファイルシステムへの変更は一切行わない
- フラグなしの場合は既存動作を完全に維持

## セルフレビュー実施済み

レビュー: 1周実施、指摘0件

### レビュー観点
| 観点 | 結果 |
|---|---|
| 要件充足 | 全受け入れ条件を満たしている |
| バグ/セキュリティ | 問題なし |
| 規約違反 | なし |
| スコープ逸脱 | なし |
| コード重複 | なし |
