### PR TITLE
feat: setup-local.shにリンク作成結果のサマリー表示を追加

### DIFF
--- a/setup-local.sh
+++ b/setup-local.sh
@@ -5,10 +5,15 @@ cd "$(dirname "$0")"
 
 mkdir -p .claude/skills
 
+count_created=0
+count_skipped=0
+count_removed=0
+
 # 壊れたシンボリックリンクを削除
 for link in .claude/skills/*; do
   if [ -L "$link" ] && [ ! -e "$link" ]; then
     rm "$link"
+    count_removed=$((count_removed + 1))
   fi
 done
 
@@ -18,8 +23,13 @@ for dir in skills/*/; do
   target=".claude/skills/$name"
   if [ ! -e "$target" ]; then
     ln -s "../../skills/$name" "$target"
+    count_created=$((count_created + 1))
+  else
+    count_skipped=$((count_skipped + 1))
   fi
 done
 
-echo "Done. Linked skills:"
-ls -la .claude/skills/
+echo "=== Setup Complete ==="
+echo "  新規リンク作成: ${count_created}"
+echo "  既存スキップ:   ${count_skipped}"
+echo "  壊れたリンク削除: ${count_removed}"


### PR DESCRIPTION
## Summary

- `setup-local.sh` の実行結果を構造化されたサマリー表示に変更
- 新規リンク作成数、既存スキップ数、壊れたリンク削除数をカウントして表示
- 従来の `ls -la` による一覧出力を、3項目のサマリーに置き換え

## 変更内容

- カウンター変数（`count_created`, `count_skipped`, `count_removed`）を追加
- 壊れたリンク削除時に `count_removed` をインクリメント
- リンク作成時に `count_created`、既存スキップ時に `count_skipped` をインクリメント
- 最後にサマリーを出力（`=== Setup Complete ===` + 3行の集計）

## 出力例

```
=== Setup Complete ===
  新規リンク作成: 2
  既存スキップ:   3
  壊れたリンク削除: 0
```

## Test plan

- [ ] 初回実行（リンクなし状態）で新規リンク数が正しく表示されること
- [ ] 再実行（リンクあり状態）で既存スキップ数が正しく表示されること
- [ ] 壊れたリンクがある場合に削除数が正しく表示されること

Generated with [Claude Code](https://claude.com/claude-code)
