### PR TITLE
feat: setup-local.shに--dry-runオプションを追加

### DIFF
--- a/setup-local.sh
+++ b/setup-local.sh
@@ -3,12 +3,32 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-mkdir -p .claude/skills
+# --dry-run オプションの解析
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+  esac
+done
+
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] 実際の変更は行いません"
+fi
+
+if [ "$DRY_RUN" = false ]; then
+  mkdir -p .claude/skills
+fi
 
 # 壊れたシンボリックリンクを削除
 for link in .claude/skills/*; do
   if [ -L "$link" ] && [ ! -e "$link" ]; then
-    rm "$link"
+    if [ "$DRY_RUN" = true ]; then
+      echo "[DRY RUN] Would remove broken link: $link"
+    else
+      rm "$link"
+    fi
   fi
 done
 
@@ -16,10 +36,16 @@ done
 for dir in skills/*/; do
   name=$(basename "$dir")
   target=".claude/skills/$name"
-  if [ ! -e "$target" ]; then
-    ln -s "../../skills/$name" "$target"
+  if [ ! -e "$target" ] && [ ! -L "$target" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "[DRY RUN] Would create link: $target -> ../../skills/$name"
+    else
+      ln -s "../../skills/$name" "$target"
+    fi
   fi
 done
 
-echo "Done. Linked skills:"
-ls -la .claude/skills/
+if [ "$DRY_RUN" = false ]; then
+  echo "Done. Linked skills:"
+  ls -la .claude/skills/
+fi


### PR DESCRIPTION
## Summary

- `setup-local.sh` に `--dry-run` オプションを追加
- `--dry-run` 指定時は実際のファイルシステム変更（ディレクトリ作成、リンク作成・削除）を行わず、実行予定の操作を `[DRY RUN]` プレフィックス付きで表示する
- フラグなし時の既存動作は変更なし

## 変更内容

- コマンドライン引数を解析し `--dry-run` フラグを検出
- `mkdir -p`, `rm`, `ln -s` の各操作をdry-run分岐で囲み、dry-run時は表示のみ
- リンク存在チェックに `[ ! -L "$target" ]` を追加し、壊れたシンボリックリンクのケースにも対応

## Test plan

- [ ] `./setup-local.sh --dry-run` で実行時、ファイルシステムに変更が発生しないこと
- [ ] `./setup-local.sh` で実行時、従来通りリンクが作成されること
- [ ] 壊れたリンクがある状態で `--dry-run` を実行すると `Would remove broken link` メッセージが表示されること

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
