### PR TITLE
feat: setup-local.shにリンク作成結果のサマリー表示を追加

### DIFF
--- a/setup-local.sh
+++ b/setup-local.sh
@@ -5,10 +5,16 @@ cd "$(dirname "$0")"
 
 mkdir -p .claude/skills
 
+# カウンター初期化
+created=0
+skipped=0
+removed=0
+
 # 壊れたシンボリックリンクを削除
 for link in .claude/skills/*; do
   if [ -L "$link" ] && [ ! -e "$link" ]; then
     rm "$link"
+    removed=$((removed + 1))
   fi
 done
 
@@ -18,8 +24,13 @@ for dir in skills/*/; do
   target=".claude/skills/$name"
   if [ ! -e "$target" ]; then
     ln -s "../../skills/$name" "$target"
+    created=$((created + 1))
+  else
+    skipped=$((skipped + 1))
   fi
 done
 
 echo "Done. Linked skills:"
 ls -la .claude/skills/
+echo ""
+echo "Summary: created=$created, skipped=$skipped (already exist), removed=$removed (broken)"


### PR DESCRIPTION
## 概要

`setup-local.sh` の実行完了時に、リンク作成結果のサマリーを表示するようにした。

### 変更内容

- 新規リンク作成数（`created`）、既存スキップ数（`skipped`）、壊れたリンク削除数（`removed`）をカウントする変数を追加
- 実行完了時にサマリー行を出力: `Summary: created=N, skipped=N (already exist), removed=N (broken)`

### 出力例

```
Done. Linked skills:
...
Summary: created=2, skipped=3 (already exist), removed=0 (broken)
```

## セルフレビュー実施済み

レビュー: 1周実施、指摘0件

### 総評
指摘0件（要件充足: OK, バグ/セキュリティ: OK, 規約違反: OK, スコープ逸脱: OK, コード重複: OK）