### PR TITLE
feat: setup-local.shに--dry-runオプションを追加

### DIFF
--- a/setup-local.sh
+++ b/setup-local.sh
@@ -3,12 +3,30 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-mkdir -p .claude/skills
+# --dry-run オプションの解析
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+  esac
+done
+
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] Would create directory: .claude/skills"
+else
+  mkdir -p .claude/skills
+fi
 
 # 壊れたシンボリックリンクを削除
 for link in .claude/skills/*; do
   if [ -L "$link" ] && [ ! -e "$link" ]; then
-    rm "$link"
+    if [ "$DRY_RUN" = true ]; then
+      echo "[DRY RUN] Would remove broken link: $link"
+    else
+      rm "$link"
+    fi
   fi
 done
 
@@ -17,9 +35,17 @@ for dir in skills/*/; do
   name=$(basename "$dir")
   target=".claude/skills/$name"
   if [ ! -e "$target" ]; then
-    ln -s "../../skills/$name" "$target"
+    if [ "$DRY_RUN" = true ]; then
+      echo "[DRY RUN] Would create link: $target -> ../../skills/$name"
+    else
+      ln -s "../../skills/$name" "$target"
+    fi
   fi
 done
 
-echo "Done. Linked skills:"
-ls -la .claude/skills/
+if [ "$DRY_RUN" = true ]; then
+  echo "[DRY RUN] No changes were made."
+else
+  echo "Done. Linked skills:"
+  ls -la .claude/skills/
+fi


### PR DESCRIPTION
## 概要

Issue #42 の対応として、`setup-local.sh`に`--dry-run`オプションを追加。

- `--dry-run`フラグ指定時は、ファイルシステムへの変更を行わず、実行される操作を`[DRY RUN]`プレフィクス付きで表示のみする
- ディレクトリ作成、壊れたシンボリックリンクの削除、リンク作成の全操作がdry-run対象
- フラグなしの既存動作は変更なし

Closes #42

## セルフレビュー実施済み

レビュー: 1周実施、指摘0件を修正済み

### 修正した指摘
| 指摘 | 対応内容 | コミット |
|---|---|---|
| (指摘なし) | - | - |