### PR TITLE
feat: marketplace.json追加とインストール手順の整備

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "dev-workflow",
+  "owner": {
+    "name": "Kuchita El"
+  },
+  "plugins": [
+    {
+      "name": "dev-workflow",
+      "source": "./"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Claude Code向けの汎用スキルライブラリ。プロジェクト固有の
 
 ### Repository Structure
 
+- `.claude-plugin/plugin.json` — プラグイン定義（名前・バージョン・説明）
+- `.claude-plugin/marketplace.json` — マーケットプレイス定義（プラグイン配布用カタログ）
 - `skills/{skill-name}/SKILL.md` — 各スキルの定義ファイル（本体）
 - `skills/{skill-name}/references/` — スキルが参照する補助ファイル（テンプレート、デフォルト定義等）
 - `skills/{skill-name}/agents/` — サブエージェント定義ファイル（プロンプトテンプレート）

--- a/README.md
+++ b/README.md
@@ -4,7 +4,27 @@ Claude Code向けの汎用スキル集です。プロジェクト固有の依存
 
 ## 導入方法
 
-### 1. スキルのコピー
+### 方法1: プラグインとしてインストール（推奨）
+
+マーケットプレイス経由でインストールできます:
+
+```bash
+# マーケットプレイスを登録
+/plugin marketplace add kuchita-el/claude-shared-skills
+
+# プラグインをインストール
+/plugin install dev-workflow@dev-workflow
+```
+
+スコープを指定してインストール先を選択できます:
+
+| スコープ | 保存先 | 共有範囲 |
+|---|---|---|
+| `--scope user` | `~/.claude/settings.json` | 全プロジェクト共通 |
+| `--scope project` | `.claude/settings.json` | チーム全員（リポジトリにコミット） |
+| `--scope local` | `.claude/settings.local.json` | 自分のみ |
+
+### 方法2: スキルのコピー
 
 使いたいスキルを `.claude/skills/` にコピーしてください:
 
@@ -16,7 +36,7 @@ cp -r skills/* /path/to/your-project/.claude/skills/
 cp -r skills/dev-loop /path/to/your-project/.claude/skills/
 ```
 
-### 2. DoR定義のカスタマイズ（オプション）
+### DoR定義のカスタマイズ（オプション）
 
 `/refine-issue` はDoR定義を参照します。スキル同梱のデフォルト定義（`skills/refine-issue/references/dor-default.md`）がそのまま使われますが、プロジェクトに合わせてカスタマイズする場合は `.claude/dor/definition.md` を配置してください:
 


### PR DESCRIPTION
## Summary
- `.claude-plugin/marketplace.json` を追加し、マーケットプレイス経由でのプラグインインストールを可能にした
- README.mdにプラグインインストール手順を推奨方法として追記
- CLAUDE.mdのRepository Structureに `plugin.json` / `marketplace.json` の説明を追記

## 利用側での導入手順

```bash
/plugin marketplace add kuchita-el/claude-shared-skills
/plugin install dev-workflow@dev-workflow
```

## Test plan
- [ ] `claude --plugin-dir .` でローカル起動し、既存スキルが動作すること
- [ ] `/plugin marketplace add` でマーケットプレイスとして登録できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
