### PR TITLE
fix: マーケットプレイス名をclaude-shared-skillsに変更

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "dev-workflow",
+  "name": "claude-shared-skills",
   "owner": {
     "name": "Kuchita El"
   },

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Claude Code向けの汎用スキル集です。プロジェクト固有の依存
 /plugin marketplace add kuchita-el/claude-shared-skills
 
 # プラグインをインストール
-/plugin install dev-workflow@dev-workflow
+/plugin install dev-workflow@claude-shared-skills
 ```
 
 スコープを指定してインストール先を選択できます:


### PR DESCRIPTION
## Summary
- marketplace.jsonの`name`を `dev-workflow` → `claude-shared-skills`（リポジトリ名）に変更
- README.mdのインストールコマンドを追従修正: `/plugin install dev-workflow@claude-shared-skills`

## Test plan
- [x] `/plugin marketplace add` でマーケットプレイス名が `claude-shared-skills` として認識されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
