### PR TITLE
feat: DDDドキュメントリント実装（#159）

### DIFF
--- a/docs/development/lint-domain-doc-setup.md
+++ b/docs/development/lint-domain-doc-setup.md
@@ -1,0 +1,119 @@
+# DDDドキュメントリント運用ガイド
+
+`scripts/lint-domain-doc.sh` をローカル開発（pre-commit hook）と CI（GitHub Actions）に組み込むための設定例。
+
+## スクリプト概要
+
+`scripts/lint-domain-doc.sh` は DDD ドキュメントの **記法逸脱・命名規約違反** を機械検出する bash スクリプト。
+
+- **検査対象（既定）**:
+  - `docs/development/event-storming.md`
+  - `docs/development/domain-model.md`
+  - `docs/qa/event-storming.md`
+- **検出項目**:
+  - 禁止記号: `->`、`=>`、`<>`、`Result<`、行頭の `type`、` ```fsharp ` ラベル（Mermaid ブロック内は除外）
+  - 命名規約: 集約セクション（`## XXX集約`）配下の `### コマンド` / `### 発火するイベント` / `### 状態遷移` 配下のコードブロック内、行頭定義行の語尾判定（**日本語名のみ**）
+- **exit code**:
+  - `0`: 違反0件
+  - `1`: 違反検出
+  - `2`: 入力ファイル不存在
+  - `3`: GNU grep（`grep -P` 対応）不在
+- **依存**: `bash` ≥ 4.x、GNU grep（Linux または `brew install grep` 済みの macOS）
+
+## 基本実行例
+
+```sh
+# 既定の3ファイルを検査
+bash scripts/lint-domain-doc.sh
+
+# 個別ファイルのみ検査（pre-commit から staged ファイルを渡す等）
+bash scripts/lint-domain-doc.sh docs/development/domain-model.md
+```
+
+違反が検出されると `{ファイル}:{行番号}: {違反種別}: ...` 形式で標準出力に出力され、exit code が非0になる。
+
+## pre-commit hook 設定例
+
+### A. `.git/hooks/pre-commit` 直貼り版（個人開発者向け）
+
+`.git/hooks/pre-commit` に以下を配置し、`chmod +x .git/hooks/pre-commit` で実行権を付与する。
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DDDドキュメントの staged 差分のみリント
+targets=(
+    "docs/development/event-storming.md"
+    "docs/development/domain-model.md"
+    "docs/qa/event-storming.md"
+)
+
+# staged ファイルから対象パスを抽出
+mapfile -t staged < <(
+    git diff --cached --name-only --diff-filter=ACM | \
+        grep -Fxf <(printf '%s\n' "${targets[@]}") || true
+)
+
+if [ "${#staged[@]}" -gt 0 ]; then
+    bash scripts/lint-domain-doc.sh "${staged[@]}"
+fi
+```
+
+DDD ドキュメント以外を編集する commit には影響しない（staged に対象ファイルがなければスキップ）。
+
+### B. `pre-commit` フレームワーク版（チーム共有向け）
+
+[pre-commit](https://pre-commit.com/) を使う場合、リポジトリ直下の `.pre-commit-config.yaml` に local hook として登録する。
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: lint-domain-doc
+        name: DDD ドキュメントリント
+        entry: bash scripts/lint-domain-doc.sh
+        language: system
+        files: '^docs/(development|qa)/(event-storming|domain-model)\.md$'
+        pass_filenames: true
+```
+
+`pass_filenames: true` により、staged の対象ファイルだけがスクリプト引数として渡される。導入後は `pre-commit install` でフックを有効化する。
+
+## CI 設定例（GitHub Actions）
+
+`.github/workflows/lint-ddd-doc.yml` 雛形:
+
+```yaml
+name: DDD doc lint
+
+on:
+  pull_request:
+    paths:
+      - "docs/development/event-storming.md"
+      - "docs/development/domain-model.md"
+      - "docs/qa/event-storming.md"
+      - "scripts/lint-domain-doc.sh"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint-domain-doc.sh
+        run: bash scripts/lint-domain-doc.sh
+```
+
+`ubuntu-latest` は GNU grep を含むため追加セットアップ不要。違反検出時は exit code 1 でジョブが失敗する。
+
+## 既知の制約
+
+- **GNU grep 依存**: 日本語文字判定に `grep -P`（PCRE）を使用。BSD grep / macOS デフォルト grep では動作しない（exit 3 でエラー終了）。macOS では `brew install grep` 後に PATH 上で GNU grep が優先されるよう設定する。
+- **手動検証のみ**: スクリプト自体の自動ユニットテストは未導入。検出ロジックの境界ケースは fixture（手書き md）と既存ドキュメントへの実測で確認する。
+- **許容誤検知**: 失敗理由型（`〜失敗理由 =`）・サブエンティティ型・「〜状態遷移」のような末尾は語尾判定で違反扱いになる。フェーズ1では除外ルールを導入せず、違反修正側でチューニングする方針。
+- **英語名は対象外**: 命名規約検査は日本語含有行のみ。英語名（`createPlan` 等）はスキップされる。
+
+## 動作確認済み
+
+- 2026-04-29: 既存DDDドキュメント3本に対する実測で命名規約違反 11 件を検出（禁止記号は0件）。
+- 2026-04-29: A 案 pre-commit スニペットを `.git/hooks/pre-commit` に貼り付け、違反入りファイルを `git add` → `git commit` 試行で commit が失敗することを確認。違反0件のファイルでは commit が正常完了することを確認。

--- a/scripts/lint-domain-doc.sh
+++ b/scripts/lint-domain-doc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # DDDドキュメントリント
 # - 禁止記号の検出
-# - 命名規約の検査（日本語名のみ）
+# - 命名規約の検査（日本語名のみ、集約セクション配下の指定3見出し配下のコードブロック内）
 #
 # 使い方:
 #   bash scripts/lint-domain-doc.sh             # 固定3ファイルを検査
@@ -39,13 +39,98 @@ for f in "${files[@]}"; do
     fi
 done
 
-# 違反カウンタ
+# 違反カウンタ（lint_file 関数内から更新する）
 violations=0
 
-# 1ファイルを行単位で走査して禁止記号を検出
+# 禁止記号検出
+check_prohibited() {
+    local file="$1"
+    local line_num="$2"
+    local line="$3"
+
+    if [[ "${line:0:9}" == '```fsharp' ]]; then
+        printf '%s:%d: 禁止記号: ```fsharp\n' "$file" "$line_num"
+        violations=$((violations + 1))
+    fi
+    if [[ "$line" =~ ^type([[:space:]]|$) ]]; then
+        printf '%s:%d: 禁止記号: ^type\n' "$file" "$line_num"
+        violations=$((violations + 1))
+    fi
+    if [[ "$line" == *'->'* ]]; then
+        printf '%s:%d: 禁止記号: ->\n' "$file" "$line_num"
+        violations=$((violations + 1))
+    fi
+    if [[ "$line" == *'=>'* ]]; then
+        printf '%s:%d: 禁止記号: =>\n' "$file" "$line_num"
+        violations=$((violations + 1))
+    fi
+    if [[ "$line" == *'<>'* ]]; then
+        printf '%s:%d: 禁止記号: <>\n' "$file" "$line_num"
+        violations=$((violations + 1))
+    fi
+    if [[ "$line" == *'Result<'* ]]; then
+        printf '%s:%d: 禁止記号: Result<\n' "$file" "$line_num"
+        violations=$((violations + 1))
+    fi
+}
+
+# 命名規約検査
+check_naming() {
+    local file="$1"
+    local line_num="$2"
+    local line="$3"
+    local section="$4"
+    local name
+
+    # 行頭定義行: インデントなしで `=` or `:` を含む
+    if ! [[ "$line" =~ ^[^[:space:]][^=:]*[=:] ]]; then
+        return
+    fi
+
+    # 名前部分: 最初の `=`/`:` 手前まで
+    name="${line%%[=:]*}"
+    # 前後空白除去
+    name="${name#"${name%%[![:space:]]*}"}"
+    name="${name%"${name##*[![:space:]]}"}"
+
+    if [ -z "$name" ]; then
+        return
+    fi
+
+    # 日本語含有判定（ひらがな・カタカナ・漢字）
+    if ! grep -qP '[\x{3040}-\x{30ff}\x{4e00}-\x{9fff}]' <<<"$name"; then
+        return  # 英語名は対象外
+    fi
+
+    case "$section" in
+        コマンド)
+            if [[ "$name" != *する ]]; then
+                printf '%s:%d: 命名規約: %s: コマンド名は動詞句でない\n' "$file" "$line_num" "$name"
+                violations=$((violations + 1))
+            fi
+            ;;
+        発火するイベント)
+            if [[ "$name" != *した && "$name" != *された ]]; then
+                printf '%s:%d: 命名規約: %s: イベント名は過去形でない\n' "$file" "$line_num" "$name"
+                violations=$((violations + 1))
+            fi
+            ;;
+        状態遷移)
+            if [[ "$name" != *する ]]; then
+                printf '%s:%d: 命名規約: %s: 状態遷移名は動詞句でない\n' "$file" "$line_num" "$name"
+                violations=$((violations + 1))
+            fi
+            ;;
+    esac
+}
+
+# 1ファイルを行単位で 1 パス走査
 lint_file() {
     local file="$1"
     local in_mermaid=0
+    local in_target_lang_block=0
+    local current_aggregate=0
+    local current_section=""
     local line_num=0
     local line label
 
@@ -56,41 +141,48 @@ lint_file() {
         if [[ "${line:0:3}" == '```' ]]; then
             if [ "$in_mermaid" -eq 1 ]; then
                 in_mermaid=0
+            elif [ "$in_target_lang_block" -eq 1 ]; then
+                in_target_lang_block=0
             else
+                # 開始: ラベル抽出
                 label="${line:3}"
                 label="${label%%[[:space:]]*}"
                 if [ "$label" = "mermaid" ]; then
                     in_mermaid=1
+                elif [ "$label" = "fsharp" ] || [ -z "$label" ]; then
+                    in_target_lang_block=1
+                fi
+                # 他のラベルは何もしない
+            fi
+        else
+            # コードブロック外でのみ見出し処理
+            if [ "$in_mermaid" -eq 0 ] && [ "$in_target_lang_block" -eq 0 ]; then
+                # H2 見出し（H3 とは区別）
+                if [[ "$line" =~ ^##[[:space:]] ]] && ! [[ "$line" =~ ^### ]]; then
+                    if [[ "$line" =~ ^##[[:space:]].+集約[[:space:]]*$ ]]; then
+                        current_aggregate=1
+                    else
+                        current_aggregate=0
+                    fi
+                    current_section=""
+                fi
+                # H3 見出し
+                if [[ "$line" =~ ^###[[:space:]](コマンド|発火するイベント|状態遷移)[[:space:]]*$ ]]; then
+                    current_section="${BASH_REMATCH[1]}"
+                elif [[ "$line" =~ ^###[[:space:]] ]]; then
+                    current_section=""
                 fi
             fi
         fi
 
         # 禁止記号検出（Mermaidブロック内は除外）
         if [ "$in_mermaid" -eq 0 ]; then
-            if [[ "${line:0:9}" == '```fsharp' ]]; then
-                printf '%s:%d: 禁止記号: ```fsharp\n' "$file" "$line_num"
-                violations=$((violations + 1))
-            fi
-            if [[ "$line" =~ ^type([[:space:]]|$) ]]; then
-                printf '%s:%d: 禁止記号: ^type\n' "$file" "$line_num"
-                violations=$((violations + 1))
-            fi
-            if [[ "$line" == *'->'* ]]; then
-                printf '%s:%d: 禁止記号: ->\n' "$file" "$line_num"
-                violations=$((violations + 1))
-            fi
-            if [[ "$line" == *'=>'* ]]; then
-                printf '%s:%d: 禁止記号: =>\n' "$file" "$line_num"
-                violations=$((violations + 1))
-            fi
-            if [[ "$line" == *'<>'* ]]; then
-                printf '%s:%d: 禁止記号: <>\n' "$file" "$line_num"
-                violations=$((violations + 1))
-            fi
-            if [[ "$line" == *'Result<'* ]]; then
-                printf '%s:%d: 禁止記号: Result<\n' "$file" "$line_num"
-                violations=$((violations + 1))
-            fi
+            check_prohibited "$file" "$line_num" "$line"
+        fi
+
+        # 命名規約検査（naming_target_block）
+        if [ "$current_aggregate" -eq 1 ] && [ -n "$current_section" ] && [ "$in_target_lang_block" -eq 1 ]; then
+            check_naming "$file" "$line_num" "$line" "$current_section"
         fi
     done < "$file"
 }

--- a/scripts/lint-domain-doc.sh
+++ b/scripts/lint-domain-doc.sh
@@ -42,9 +42,61 @@ done
 # 違反カウンタ
 violations=0
 
-# 各ファイルを処理（Task 2/3 で本実装）
+# 1ファイルを行単位で走査して禁止記号を検出
+lint_file() {
+    local file="$1"
+    local in_mermaid=0
+    local line_num=0
+    local line label
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        line_num=$((line_num + 1))
+
+        # コードブロック開閉判定（行頭3バックティック）
+        if [[ "${line:0:3}" == '```' ]]; then
+            if [ "$in_mermaid" -eq 1 ]; then
+                in_mermaid=0
+            else
+                label="${line:3}"
+                label="${label%%[[:space:]]*}"
+                if [ "$label" = "mermaid" ]; then
+                    in_mermaid=1
+                fi
+            fi
+        fi
+
+        # 禁止記号検出（Mermaidブロック内は除外）
+        if [ "$in_mermaid" -eq 0 ]; then
+            if [[ "${line:0:9}" == '```fsharp' ]]; then
+                printf '%s:%d: 禁止記号: ```fsharp\n' "$file" "$line_num"
+                violations=$((violations + 1))
+            fi
+            if [[ "$line" =~ ^type([[:space:]]|$) ]]; then
+                printf '%s:%d: 禁止記号: ^type\n' "$file" "$line_num"
+                violations=$((violations + 1))
+            fi
+            if [[ "$line" == *'->'* ]]; then
+                printf '%s:%d: 禁止記号: ->\n' "$file" "$line_num"
+                violations=$((violations + 1))
+            fi
+            if [[ "$line" == *'=>'* ]]; then
+                printf '%s:%d: 禁止記号: =>\n' "$file" "$line_num"
+                violations=$((violations + 1))
+            fi
+            if [[ "$line" == *'<>'* ]]; then
+                printf '%s:%d: 禁止記号: <>\n' "$file" "$line_num"
+                violations=$((violations + 1))
+            fi
+            if [[ "$line" == *'Result<'* ]]; then
+                printf '%s:%d: 禁止記号: Result<\n' "$file" "$line_num"
+                violations=$((violations + 1))
+            fi
+        fi
+    done < "$file"
+}
+
 for file in "${files[@]}"; do
-    : "$file"
+    lint_file "$file"
 done
 
 if [ "$violations" -gt 0 ]; then

--- a/scripts/lint-domain-doc.sh
+++ b/scripts/lint-domain-doc.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# DDDドキュメントリント
+# - 禁止記号の検出
+# - 命名規約の検査（日本語名のみ）
+#
+# 使い方:
+#   bash scripts/lint-domain-doc.sh             # 固定3ファイルを検査
+#   bash scripts/lint-domain-doc.sh path/...    # 指定ファイルのみ検査
+#
+# exit code:
+#   0: 違反0件
+#   1: 違反検出
+#   2: 入力ファイル不存在
+#   3: GNU grep 不在
+set -euo pipefail
+
+# 環境前提検証: GNU grep（grep -P 対応）が必要
+if ! grep -P -q . <<<"x" 2>/dev/null; then
+    echo "エラー: GNU grep（grep -P 対応）が必要です。Linux を使うか、macOS では 'brew install grep' を実行してください。" >&2
+    exit 3
+fi
+
+# 対象ファイルの決定
+if [ "$#" -eq 0 ]; then
+    files=(
+        "docs/development/event-storming.md"
+        "docs/development/domain-model.md"
+        "docs/qa/event-storming.md"
+    )
+else
+    files=("$@")
+fi
+
+# ファイル存在確認
+for f in "${files[@]}"; do
+    if [ ! -f "$f" ]; then
+        echo "エラー: ファイルが見つかりません: $f" >&2
+        exit 2
+    fi
+done
+
+# 違反カウンタ
+violations=0
+
+# 各ファイルを処理（Task 2/3 で本実装）
+for file in "${files[@]}"; do
+    : "$file"
+done
+
+if [ "$violations" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Issue #159 で承認されたフェーズ1（grepベースのDDDドキュメントリント）を実装した。`scripts/lint-domain-doc.sh` で記法逸脱・命名規約違反を機械検出し、pre-commit hook と GitHub Actions の運用ガイドを `docs/development/lint-domain-doc-setup.md` に整備。

Closes #159
Refs #157（親 Issue）

## 実装内容

| ファイル | 内容 |
|---|---|
| `scripts/lint-domain-doc.sh` | 1パス状態機械方式の bash リンタ（禁止記号・命名規約） |
| `docs/development/lint-domain-doc-setup.md` | pre-commit / GitHub Actions 設定例と運用上の制約 |

### 検出仕様

- **禁止記号**（Mermaid ブロック内除外）: `->`, `=>`, `<>`, `Result<`, 行頭 `type`, ` ```fsharp ` ラベル
- **命名規約**（日本語名のみ）: 集約セクション(`## XXX集約`)配下の `### コマンド` / `### 発火するイベント` / `### 状態遷移` 配下のコードブロック内、行頭定義行の語尾判定
  - コマンド・状態遷移: 末尾 `する`
  - イベント: 末尾 `した` / `された`

### exit code

| code | 意味 |
|---|---|
| 0 | 違反0件 |
| 1 | 違反検出 |
| 2 | 入力ファイル不存在 |
| 3 | GNU grep 不在 |

## 実測結果

3ファイルへの初回実行で `docs/development/domain-model.md` に **命名規約違反 11 件**（禁止記号は0件）。Mermaid ブロック内の `-->` 等60件以上は除外フィルタにより誤検出されないことを確認。

違反内訳と修正方針の検討は別 Issue **#166** に切り出した。

## セルフレビュー実施済み

レビュー1周、ブロッカー0件。

### レビュー契約

| # | 契約項目 | 判定 |
|---|---|---|
| 1 | bash で実装 | ✅ |
| 2 | Mermaid ブロック内の `-->`/`==` が誤検出されない | ✅ |
| 3 | ` ```fsharp `/`->`/`=>`/`<>`/`Result<`/`^type` を禁止記号として検出 | ✅ |
| 4 | コマンド「〜する」末尾検査 | ✅ |
| 5 | イベント「〜した」「〜された」末尾検査 | ✅ |
| 6 | 状態遷移「〜する」末尾検査 | ✅ |
| 7 | `## XXX集約` 以外の H2 配下では命名検査が発動しない | ✅ |
| 8 | 引数で渡したファイルのみ検査対象 | ✅ |
| 9 | 違反0件で exit 0 / 違反検出で exit 1 | ✅ |
| 10 | ファイル名・行番号付き出力 | ✅ |
| 11 | 失敗理由型・サブエンティティも違反として検出（許容誤検知） | ✅ |
| 12 | `fsharp` ラベルブロックも命名検査対象 | ✅ |
| 13 | 英語名は命名検査対象外 | ✅ |
| 14 | ファイル不存在で exit 2 / GNU grep 不在で exit 3 | ✅ |
| 15 | pre-commit 設定例ドキュメント化 | ✅ |
| 16 | GitHub Actions 設定例ドキュメント化 | ✅ |
| 17 | 違反修正用 Issue 起票 | ✅（#166） |

### 改善提案（未対応）

| 重大度 | ファイル | 指摘 | 備考 |
|---|---|---|---|
| 改善提案 | `scripts/lint-domain-doc.sh:53-77` | 6種の禁止記号検出が連続 `if` 文で羅列され、配列+ループ化で短縮できる | 各記号で表示文字列が異なり現行の羅列のほうが読みやすいため許容。レビュアーの判断に委ねる。 |

## テスト方針

計画書（`docs/plans/issue-159.md` §検証方針）通り、自動ユニットテストは導入せず手動検証で代替。

- fixture（`/tmp/lint-fixture-*.md`）で6種禁止記号と命名規約の境界ケースを確認
- 既存DDDドキュメント3本への実測で Mermaid 除外と違反一覧を確認
- pre-commit 設定例の動作確認: 違反入りファイルで `git commit` 失敗、違反0件ファイルで pre-commit 通過を確認

## 関連

- 親 Issue #157
- 違反修正フォローアップ #166
- 編集負担が顕在化した契機 PR #156
