### PR TITLE
lint-domain-doc.sh: GNU grep / LC_ALL 依存撤去 (#195)

### DIFF
--- a/docs/development/lint-domain-doc-setup.md
+++ b/docs/development/lint-domain-doc-setup.md
@@ -17,8 +17,7 @@
   - `0`: 違反0件
   - `1`: 違反検出
   - `2`: 入力ファイル不存在
-  - `3`: GNU grep（`grep -P` 対応）不在
-- **依存**: `bash` ≥ 4.x、GNU grep（Linux または `brew install grep` 済みの macOS）
+- **依存**: `bash` ≥ 4.x
 
 ## 基本実行例
 
@@ -104,11 +103,10 @@ jobs:
         run: bash scripts/lint-domain-doc.sh
 ```
 
-`ubuntu-latest` は GNU grep を含むため追加セットアップ不要。違反検出時は exit code 1 でジョブが失敗する。
+`ubuntu-latest` 標準環境で追加セットアップ不要。違反検出時は exit code 1 でジョブが失敗する。
 
 ## 既知の制約
 
-- **GNU grep 依存**: 日本語文字判定に `grep -P`（PCRE）を使用。BSD grep / macOS デフォルト grep では動作しない（exit 3 でエラー終了）。macOS では `brew install grep` 後に PATH 上で GNU grep が優先されるよう設定する。
 - **自動テスト**: `scripts/test-lint-domain-doc.sh` で fixture（`scripts/fixtures/lint-domain-doc/{valid,invalid}/*.md`）に対する exit code とメッセージ部分一致をアサートする。CI 連携は未導入（ローカル実行のみ）。
 - **命名規約は機械検証対象外**: イベント=過去形、コマンド=動詞句〔う段終止形〕等の命名規約はLinterの機械検証から撤退済（背景: `domain-model-notation.md` の「Linter による機械検証の撤退について」）。命名遵守は規約参照と人間レビューで補完する。
 - **失敗理由独立型は違反**: `〜失敗理由 =` のような独立型定義は廃止記法として違反検出される。Either.Left 系の同期失敗はコマンドの `失敗時:` 配下に箇条書きで記述する（空なら省略）。ドメインイベント系失敗（`〜が失敗した` 等、境界を超えて他者が観測する事実）は `イベント:` 配下に発火イベントとして列挙する（`失敗時:` 配下への混入は意味境界違反だが、本リントは意味境界の機械検査は行わない。レビューで補完すること）。
@@ -120,3 +118,4 @@ jobs:
 - 2026-04-30: 記法刷新（#168）に伴い、検査ロジックを更新（う段9文字終止形・状態遷移廃止検出・失敗理由独立型廃止検出・契機フィールド必須化）。fixture テストランナー `scripts/test-lint-domain-doc.sh` を導入し、valid 4件 + invalid 4件で全パスを確認。
 - 2026-05-09: 命名規約検査（イベント名・コマンド名・状態遷移名）と廃止セクション存在検査を削除（#192）。Linter は構造検証（禁止記号・廃止記法独立型定義・契機フィールド必須化）に専念。fixture を valid 4件 + invalid 2件に再編し全パスを確認。
 - 2026-05-09: 契機フィールド検査削除（#187）。Linter は禁止記号検査・廃止記法検出（失敗理由独立型）の2系統に絞り込み。fixture を valid 4件 + invalid 1件に再編し全パスを確認。
+- 2026-05-09: GNU grep / `LC_ALL` 依存撤去（#195）。lint 本体から PCRE 対応性検査と `LC_ALL=C.UTF-8` 明示を削除し、運用ガイドから macOS セットアップ手順を削除。fixture テスト 5/5 パス・既定3ファイル違反0件を確認（macOS 実機確認は別Issueでマトリクス化検討）。

--- a/scripts/lint-domain-doc.sh
+++ b/scripts/lint-domain-doc.sh
@@ -4,7 +4,7 @@
 # - 廃止記法検出: `〜失敗理由 =` 独立型定義（コマンド内 `失敗時:` 配下に箇条書き化）
 #
 # 命名規約（イベント=過去形、コマンド=動詞辞書形 等）は形態素解析を要する
-# 言語学的判定であり、grep ベースでは原理的に誤検出・誤許容が生じるため
+# 言語学的判定であり、機械的判定では原理的に誤検出・誤許容が生じるため
 # 機械検証対象外とする。命名規約自体は
 # `skills/domain-modeling/references/domain-model-notation.md` に維持し、
 # 人が守る規約として運用する（機械化再導入は #157 フェーズ2以降で検討）。
@@ -17,18 +17,7 @@
 #   0: 違反0件
 #   1: 違反検出
 #   2: 入力ファイル不存在
-#   3: GNU grep 不在
-#
-# ロケール注記:
-#   PCRE（`grep -P`）の日本語文字クラスはロケール依存のため `LC_ALL=C.UTF-8` を冒頭で明示する。
 set -euo pipefail
-export LC_ALL=C.UTF-8
-
-# 環境前提検証: GNU grep（grep -P 対応）が必要
-if ! grep -P -q . <<<"x" 2>/dev/null; then
-    echo "エラー: GNU grep（grep -P 対応）が必要です。Linux を使うか、macOS では 'brew install grep' を実行してください。" >&2
-    exit 3
-fi
 
 # 対象ファイルの決定
 if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
## 概要

closes #195

`scripts/lint-domain-doc.sh` から GNU grep（`grep -P`）対応性検査ブロックと `LC_ALL=C.UTF-8` 明示を撤去し、運用ガイド（`docs/development/lint-domain-doc-setup.md`）から GNU grep 依存・macOS セットアップ手順を削除。Issue 本文が想定していた「日本語含有判定」本体は #187 で削除済みのため、本PRは副次的依存（環境前提検査・ロケール明示・コメント・運用ガイド整合）の整理に縮退。

## 変更内容

| ファイル | 変更 |
|---|---|
| `scripts/lint-domain-doc.sh` | GNU grep 対応性検査ブロック（exit 3）削除、`export LC_ALL=C.UTF-8` 削除、ロケール注記コメント削除、ヘッダコメント整理（`grep ベース`→`機械的判定`） |
| `docs/development/lint-domain-doc-setup.md` | exit code 3・依存節の GNU grep 言及・既知の制約「GNU grep 依存」項を削除、CI 説明文を整理、動作確認履歴に本Issue対応エントリ追加 |

## 検証

| 項目 | 結果 |
|---|---|
| `bash scripts/test-lint-domain-doc.sh` | All tests passed: 5/5 |
| `bash scripts/lint-domain-doc.sh`（既定3ファイル） | exit 0（違反0件） |
| `grep -P` / `LC_ALL` の残存（スクリプト） | 0件 |
| `GNU grep` / `brew install grep` の残存（運用ガイド本体） | 0件（履歴1行のみ意図的に残存） |

macOS BSD grep 環境での実機確認はスコープ外（Issue 明記）。論理的等価性（`grep -P` 呼び出し全廃 + 既存 fixture 全パス）で代替。

## レビュー契約

| # | 項目 | 結果 |
|---|---|---|
| 1 | `scripts/lint-domain-doc.sh` から `grep -P`（PCRE）依存箇所が削除 | ✅ |
| 2 | `scripts/lint-domain-doc.sh` から GNU grep 対応性検査ブロック（exit 3）が削除 | ✅ |
| 3 | `scripts/lint-domain-doc.sh` のロケール注記・`LC_ALL=C.UTF-8` 明示が削除 | ✅ |
| 4 | `docs/development/lint-domain-doc-setup.md` の GNU grep 依存・macOS セットアップ記述が削除 | ✅ |
| 5 | `scripts/test-lint-domain-doc.sh` が全 fixture で期待通りの結果 | ✅ |
| 6 | 既存DDDドキュメントの lint 結果が現状と等価 | ✅ |

## セルフレビュー実施済み

レビュー: 1周実施、ブロッカー0件・改善提案0件

差分が小規模（4挿入16削除）かつ削除中心のため、インラインレビューで実施。レビュー契約7項目（AC 6項目 + 検証すべき振る舞い1項目）すべて合格。

## スコープ外

- 構造検証ロジック自体の改修
- 命名規約の機械検証再導入（#157 フェーズ2以降）
- 他のスクリプトの環境依存撤廃
- macOS 標準環境での実機動作確認（必要なら別Issueで CI マトリクス追加として扱う）

## 関連

- Issue #195
- 計画 `docs/plans/issue-195.md`
- 関連: #157（親）、#159（lint 実装本体）、#187（契機フィールド検査削除＝本体ロジック削除）、#192（命名規約検査削除）、#194（前段PR）
