### PR TITLE
chore: .claude/worktree/ を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Skill evaluation workspaces
 *-workspace/
 
+# Git worktrees placed inside the repo
+.claude/worktree/


### PR DESCRIPTION
## 概要

`.gitignore` に `.claude/worktree/` を追加。リポジトリ内 worktree 配置時に親リポジトリの `git status` を汚染しない対策。

## 背景

Claude Code の git worktree 機能は、worktree 配置場所として以下の2パターンが想定される。

- A: `<repo>/.claude/worktree/` 配下（リポジトリ内）
- B: リポジトリと並列のディレクトリ

A を採用した場合、worktree 内のファイルが親リポジトリで未追跡ファイルとして `git status` に検出される。Claude Code 公式ドキュメントでも当該パスの `.gitignore` 追加が推奨されている。

## 変更内容

```diff
+# Git worktrees placed inside the repo
+.claude/worktree/
```

## Test plan

- [ ] リポジトリルートで `mkdir -p .claude/worktree/test && touch .claude/worktree/test/dummy` を実行し、`git status` で未追跡ファイルとして検出されないことを確認
- [ ] 既存の `*-workspace/` パターンに影響しないことを確認

Closes (関連 issue なし)
