### PR TITLE
chore(gitignore): worktree除外パスを .claude/worktrees/ に修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *-workspace/
 
 # Git worktrees placed inside the repo
-.claude/worktree/
+.claude/worktrees/


### PR DESCRIPTION
## 概要

リポジトリ内 worktree の除外パスが実ディレクトリとマッチしていなかった問題を修正。

- 実ディレクトリ: `.claude/worktrees/`（複数形）
- 既存 `.gitignore` エントリ: `.claude/worktree/`（単数形）→ マッチせず

このため `git add -A` で worktree 配下の埋め込みGitリポジトリを巻き込む事象が発生していた。エントリを複数形へ修正し `git check-ignore` でマッチを確認済。

## 検証

```
$ git check-ignore .claude/worktrees/
.claude/worktrees/   ← マッチOK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)