### PR TITLE
chore: ADR-20260606 を Accepted へ遷移 (#228)

### DIFF
--- a/docs/adr/ADR-20260606-protection-priority-ladder.md
+++ b/docs/adr/ADR-20260606-protection-priority-ladder.md
@@ -2,9 +2,7 @@
 
 ## Status
 
-Proposed
-
-<!-- 本ADRを含むPRのマージをもって Accepted へ遷移する（提案 → 承認の二段。docs/adr/README.md 参照） -->
+Accepted
 
 ## Context
 


### PR DESCRIPTION
PR #253 のマージにより、ADR-20260606（保護手段の優先）の決定が運用入りした。Status を Proposed → Accepted へ遷移する（提案 → 承認の二段、docs/adr/README.md 準拠）。マージ案内コメントも除去。

軽微変更（1行の状態遷移）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)