### PR TITLE
docs(adr): ADR-20260513 のチーム規模軸切り出し先参照を是正 (#286)

### DIFF
--- a/docs/adr/ADR-20260513-workflow-design-scope-team.md
+++ b/docs/adr/ADR-20260513-workflow-design-scope-team.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+> 2026-06-09 正誤更新: チーム規模軸の切り出し先を `workflow-patterns.md`（#118）→ `team-workflow-patterns.md`（#284）へ是正。#118 でスコープを「パターン軸＝変更影響度に限定」と再定義し、チーム規模軸を別ファイルへ分離する決定に伴う前方参照の更新であり、本ADRの主決定（workflow-design.md からのチーム規模別フロー除外）は不変。
+
 ## Context
 
 `docs/workflow-design.md` がチーム規模・チーム構成（例: 1人開発 / 小規模チーム / 大規模チーム）への対応を含むべきかが議論となった。記述を含めると AI と人間の協働における作業フロー設計に「人間チーム間の合意形成プロセス」が混在し、設計書の焦点がぼやけるリスクが識別された。
@@ -22,7 +24,7 @@ Accepted
 3. **運用上の取り扱い**:
     - workflow-design.md のスコープセクションで本除外を免責する
     - workflow-design.md に対してチーム規模・合意形成プロセスの不足を指摘しない（レビュー時の運用ルール）
-    - チーム規模別フローが必要な場合は別ドキュメント（例: `workflow-patterns.md`、Issue #118 OPEN）に切り出す
+    - チーム規模別フローが必要な場合は別ドキュメント（`team-workflow-patterns.md`、Issue #284 OPEN）に切り出す
 
 ## Consequences
 
@@ -33,17 +35,17 @@ Accepted
 
 **受容したトレードオフ**:
 
-- チーム規模別の運用ガイドを workflow-design.md からは得られないため、別ドキュメント（Issue #118）への分離管理が必要
+- チーム規模別の運用ガイドを workflow-design.md からは得られないため、別ドキュメント（`team-workflow-patterns.md`、Issue #284）への分離管理が必要
 - 「チーム規模対応がない」という指摘がレビューで繰り返し発生する可能性がある（スコープセクションでの免責で対応）
 
 **将来の留保事項**:
 
-- パターン別ワークフロー定義（`workflow-patterns.md`、Issue #118 OPEN）でチーム規模別の運用を別途扱う
+- チーム規模別ワークフロー運用ガイド（`team-workflow-patterns.md`、Issue #284 OPEN）でチーム規模別の運用を別途扱う
 
 ## 関連ADR
 
 Related: ADR-20260402-workflow-design-v2-structure（workflow-design.md v2 構造選定。本ADRは v2 のスコープを限定する補足判定）
 
-関連Issue: #118（プラグイン共通: パターン別ワークフロー定義 `workflow-patterns.md` の設計・作成、OPEN）
+関連Issue: #284（プラグイン共通: チーム規模別ワークフロー運用ガイド `team-workflow-patterns.md` の設計・作成、OPEN）／#118（パターン別ワークフロー定義 `workflow-patterns.md` の設計・作成。本ADRが想定したチーム規模軸の切り出し先を再定義、CLOSED）
 
 由来memory: `feedback_workflow_scope_team.md`（本ADR起票によりmemory削除済、個人スコープ要素なしのため全削除）


### PR DESCRIPTION
## 概要

Issue #286 に対応。ADR-20260513「workflow-design.md にチーム規模別フローを含めない」内の、チーム規模軸の切り出し先を指す前方参照を是正した。

#118（PR #285 マージ済）でスコープを「パターン軸＝変更影響度に限定」と再定義し、チーム規模軸は別ファイル `team-workflow-patterns.md`（#284）で扱うと決定したため、ADR-20260513 が `workflow-patterns.md`（#118）を切り出し先としていた記述が陳腐化していた。

Closes #286

## 方針

ADR-20260513 の**主決定**（`workflow-design.md` からチーム規模別フローを除外）は現在も有効。#118 はむしろ「別ドキュメントへ分離」という本ADRの方針を実行したもの。よって **Superseded ではなく前方参照の正誤更新**（Status は `Accepted` 維持）で対応した。切り出し先は Decision セクションの決定事項ではなく `運用上の取り扱い`／`将来の留保事項` の例示・留保であり、ADR 機構（Superseded/Amended）を回す必要はない。

## 変更内容

| 箇所 | 変更前 | 変更後 |
|---|---|---|
| Status直下（新規） | — | `2026-06-09 正誤更新` の日付注記を追加（是正経緯・主決定不変を明記） |
| 運用上の取り扱い（25行） | `workflow-patterns.md`、Issue #118 OPEN | `team-workflow-patterns.md`、Issue #284 OPEN |
| トレードオフ（36行） | Issue #118 | `team-workflow-patterns.md`、Issue #284 |
| 将来の留保事項（41行） | `workflow-patterns.md`、Issue #118 OPEN | `team-workflow-patterns.md`、Issue #284 OPEN |
| 関連Issue（47行） | #118（OPEN） | #284（OPEN）主参照＋#118（CLOSED、切り出し先再定義の経緯として保持） |

## 受け入れ条件の充足

- [x] ADR-20260513 の切り出し先参照が `team-workflow-patterns.md`／#284 に是正されている
- [x] #118 を OPEN とする陳腐化した状態表記が解消されている（`#118 OPEN` 表記は残存ゼロを grep 確認。#118 は CLOSED の経緯参照としてのみ残置）
- [x] Status が `Accepted` のまま維持されている（Superseded 化していない）
- [x] 是正の経緯（#118 でのスコープ再定義）が日付注記として残されている

## セルフレビュー

diff 6挿入4削除の軽微な参照是正のため直接レビュー。Decision セクション（主決定）は無変更を確認。残存する `workflow-patterns.md`／#118 参照は、日付注記内の是正説明と関連Issue内の CLOSED 経緯参照のみで、いずれも意図的に保持したもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
