### PR TITLE
docs(adr): モデル制約由来の設計判断インデックスを README に追加

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -142,10 +142,9 @@ Superseded との違い:
 
 同モデルに自作物を評価させない／独立 reviewer・validator の分離／人間承認ゲートの介在。
 
-- [ADR-20260406-review-contract-in-plan-issue](./ADR-20260406-review-contract-in-plan-issue.md): 実装者自身による完了条件導出を禁じ、plan-issue 段で人間承認済み契約を作成し自己評価バイアスを除去
+- [ADR-20260406-review-contract-in-plan-issue](./ADR-20260406-review-contract-in-plan-issue.md): 正規パスでは実装者自身による完了条件導出を排し、plan-issue 段で人間承認済み契約を作成し自己評価バイアスを除去（簡易パスでの自力導出は許容）
 - [ADR-20260407-dev-loop-input-path-split](./ADR-20260407-dev-loop-input-path-split.md): 入力種別で正規/簡易パスを分け、自己評価バイアス残存と過剰準備コストのトレードオフを明示化
-- [ADR-20260601-autonomy-approval-gate-alignment](./ADR-20260601-autonomy-approval-gate-alignment.md): 自律度（承認ゲート有無）をドメインモデルではなく責任分担マトリクスで表現し、AI暴走と人間承認を層分離
-- [ADR-20260602-2-autonomy-ladder-convention](./ADR-20260602-2-autonomy-ladder-convention.md): L2 の「提案→承認」二段で AI 自走を人間承認で抑止、L3 は検証能力成熟時のみ承認段を縮退する規約を固定
+- [ADR-20260602-2-autonomy-ladder-convention](./ADR-20260602-2-autonomy-ladder-convention.md): L2 の「提案→承認」二段で AI 自走を人間承認で抑止し、L3 を AI が提案から確定まで自律実行する縮退形として定義する規約を固定
 
 ### コンテキスト膨張・トークン効率対策
 
@@ -153,14 +152,14 @@ Superseded との違い:
 
 - [ADR-20260525-subagent-claude-md-injection](./ADR-20260525-subagent-claude-md-injection.md): サブエージェントへの CLAUDE.md 自動注入挙動を利用し、明示 Read による二重読み・許可プロンプト中断を排除
 - [ADR-20260525-2-subagent-agents-consolidation](./ADR-20260525-2-subagent-agents-consolidation.md): サブエージェント定義をプラグインルートに集約し、メイン側 Read と二重読みによるトークン浪費を排除
-- [ADR-20260604-dor-shared-resource-consolidation](./ADR-20260604-dor-shared-resource-consolidation.md): DoR 定義をプラグインルートで単一ソース化し、作成側と精査側で判定基準がドリフトする早期収束を防止
+- [ADR-20260604-dor-shared-resource-consolidation](./ADR-20260604-dor-shared-resource-consolidation.md): DoR 定義をプラグインルートで単一ソース化し、作成側と精査側での重複読み込み・ドリフトを抑制
 - [ADR-20260606-2-instruction-tidying](./ADR-20260606-2-instruction-tidying.md): 指示削除ゲートを設けて指示肥大化とモデル更新時のドリフトを抑制し、確率的な指示効力低下を防ぐ
 
 ### 早期収束・手抜き対策
 
 全項目列挙強制／一部判定打ち切り防止／DoR 項目強制／単一ソース化によるドリフト防止。
 
-- [ADR-20260604-dor-shared-resource-consolidation](./ADR-20260604-dor-shared-resource-consolidation.md): DoR 定義をプラグインルートで単一ソース化し、作成側と精査側で判定基準がドリフトする早期収束を防止
+- [ADR-20260604-dor-shared-resource-consolidation](./ADR-20260604-dor-shared-resource-consolidation.md): DoR 定義を単一ソース化し、判定基準が作成側と精査側で乖離して「早期に妥当判定する」バイアスを防止
 
 ### 指示忠実性低下対策
 
@@ -184,10 +183,11 @@ Superseded との違い:
 
 ### モデル/ハーネスの固有挙動への対処
 
-プロンプトキャッシュ TTL／許可プロンプトのパース挙動／文字列⇔整数の誤判定／HEREDOC 制約／コンテキスト自動注入。
+エージェント固有の制御パラメータをドメインモデルから分離／プロンプトキャッシュ TTL／許可プロンプトのパース挙動／文字列⇔整数の誤判定／HEREDOC 制約／コンテキスト自動注入。
 
 - [ADR-20260421-agent-modeling-principle](./ADR-20260421-agent-modeling-principle.md): ループ上限・打ち切り等のエージェント固有制御パラメータをドメインモデルから排しスキル実装側に隔離
 - [ADR-20260525-subagent-claude-md-injection](./ADR-20260525-subagent-claude-md-injection.md): サブエージェントへの CLAUDE.md 自動注入挙動を利用し、明示 Read による二重読み・許可プロンプト中断を排除
+- [ADR-20260601-autonomy-approval-gate-alignment](./ADR-20260601-autonomy-approval-gate-alignment.md): 自律度（承認ゲート有無）を Command 属性として追加せず、責任分担マトリクスで表現することで、ドメインモデル層と Explanation 層を分離
 
 ### スコープ逸脱対策（ツール制限）
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -131,3 +131,75 @@ Superseded との違い:
 ## テンプレート
 
 新規 ADR を起票する際は [`./template.md`](./template.md) をコピーして使用する。MADR 準拠の必須項目（Title / Status / Context / Decision / Consequences）と本プロジェクト追加項目（関連ADR）を含む。
+
+## モデル制約由来の設計判断インデックス
+
+スキル/エージェント/参照ファイル群には「モデル（LLM）の制約への対処」が暗黙的に含まれている（自己評価バイアス、コンテキスト膨張、早期収束、指示の確率性、ハルシネーション等）。モデル更新時に「どのガードレールを見直すか・どの閾値を変更しうるか」を即座に判断できるよう、本索引で明示言及 ADR を設計要素別にクロスリファレンスする。
+
+索引対象は **モデル制約に明示言及している ADR 11 件**。暗黙該当 ADR（モデル制約由来と読めるが本文に明示記述のないもの）は対象外とする（判定境界が個別解釈に依存するため）。
+
+### 自己評価バイアス対策
+
+同モデルに自作物を評価させない／独立 reviewer・validator の分離／人間承認ゲートの介在。
+
+- [ADR-20260406-review-contract-in-plan-issue](./ADR-20260406-review-contract-in-plan-issue.md): 実装者自身による完了条件導出を禁じ、plan-issue 段で人間承認済み契約を作成し自己評価バイアスを除去
+- [ADR-20260407-dev-loop-input-path-split](./ADR-20260407-dev-loop-input-path-split.md): 入力種別で正規/簡易パスを分け、自己評価バイアス残存と過剰準備コストのトレードオフを明示化
+- [ADR-20260601-autonomy-approval-gate-alignment](./ADR-20260601-autonomy-approval-gate-alignment.md): 自律度（承認ゲート有無）をドメインモデルではなく責任分担マトリクスで表現し、AI暴走と人間承認を層分離
+- [ADR-20260602-2-autonomy-ladder-convention](./ADR-20260602-2-autonomy-ladder-convention.md): L2 の「提案→承認」二段で AI 自走を人間承認で抑止、L3 は検証能力成熟時のみ承認段を縮退する規約を固定
+
+### コンテキスト膨張・トークン効率対策
+
+サブエージェント委譲／on-demand ロード／references 分離／二重読み回避／単一ソース化。
+
+- [ADR-20260525-subagent-claude-md-injection](./ADR-20260525-subagent-claude-md-injection.md): サブエージェントへの CLAUDE.md 自動注入挙動を利用し、明示 Read による二重読み・許可プロンプト中断を排除
+- [ADR-20260525-2-subagent-agents-consolidation](./ADR-20260525-2-subagent-agents-consolidation.md): サブエージェント定義をプラグインルートに集約し、メイン側 Read と二重読みによるトークン浪費を排除
+- [ADR-20260604-dor-shared-resource-consolidation](./ADR-20260604-dor-shared-resource-consolidation.md): DoR 定義をプラグインルートで単一ソース化し、作成側と精査側で判定基準がドリフトする早期収束を防止
+- [ADR-20260606-2-instruction-tidying](./ADR-20260606-2-instruction-tidying.md): 指示削除ゲートを設けて指示肥大化とモデル更新時のドリフトを抑制し、確率的な指示効力低下を防ぐ
+
+### 早期収束・手抜き対策
+
+全項目列挙強制／一部判定打ち切り防止／DoR 項目強制／単一ソース化によるドリフト防止。
+
+- [ADR-20260604-dor-shared-resource-consolidation](./ADR-20260604-dor-shared-resource-consolidation.md): DoR 定義をプラグインルートで単一ソース化し、作成側と精査側で判定基準がドリフトする早期収束を防止
+
+### 指示忠実性低下対策
+
+指示の確率性への対応／構造による違反不可能化／指示棚卸し／重要事項の再掲。
+
+- [ADR-20260602-principles-rationale-hub](./ADR-20260602-principles-rationale-hub.md): principles.md を根拠ハブに縮退し「広さ」と「原則の射程」の混同による横断原則の取りこぼしを防止
+- [ADR-20260606-2-instruction-tidying](./ADR-20260606-2-instruction-tidying.md): 指示削除ゲートを設けて指示肥大化とモデル更新時のドリフトを抑制し、確率的な指示効力低下を防ぐ
+- [ADR-20260606-protection-priority-ladder](./ADR-20260606-protection-priority-ladder.md): 「指示は確率的にしか効かない」前提で構造・型による違反不可能化を指示追加より優先する原則を確定
+
+### ハルシネーション対策
+
+一次情報による再検証／推測禁止／Grep/Glob 実検証／実在確認の強制。
+
+該当 ADR なし（スキル定義側で対処: `plan-prompt.md`、`plan-reviewer.md`、ユーザー CLAUDE.md「検証」節 等）。**ADR 化候補**。
+
+### 並列数・モデル指定の固定
+
+モデル選定の固定／並列度上限／バッチサイズ制限／許可プロンプト挙動への配慮。
+
+該当 ADR なし（スキル定義側で対処: `refine-issue/SKILL.md`「最大3並列、モデル: sonnet」等の個別固定）。**ADR 化候補**。
+
+### モデル/ハーネスの固有挙動への対処
+
+プロンプトキャッシュ TTL／許可プロンプトのパース挙動／文字列⇔整数の誤判定／HEREDOC 制約／コンテキスト自動注入。
+
+- [ADR-20260421-agent-modeling-principle](./ADR-20260421-agent-modeling-principle.md): ループ上限・打ち切り等のエージェント固有制御パラメータをドメインモデルから排しスキル実装側に隔離
+- [ADR-20260525-subagent-claude-md-injection](./ADR-20260525-subagent-claude-md-injection.md): サブエージェントへの CLAUDE.md 自動注入挙動を利用し、明示 Read による二重読み・許可プロンプト中断を排除
+
+### スコープ逸脱対策（ツール制限）
+
+エージェントへの読み取り専用制限／Bash 実行範囲制限／破壊的操作の禁止。
+
+該当 ADR なし（エージェント定義側で対処: `code-reviewer.md`（読み取り専用）、`refactorer.md`（Bash は `git diff/status/restore*` のみ）、`test-designer.md`（読み取り専用）等）。**ADR 化候補**。
+
+### モデル更新時の見直しフロー
+
+モデル更新（コンテキスト窓拡張・検証精度向上・指示遵守性向上・自己評価バイアス減少等）が行われた際、本索引のカテゴリ順に各 ADR を再評価する。
+
+1. **設計要素別に該当 ADR を引く**: 上記カテゴリから対象設計要素の ADR を特定する
+2. **各 ADR の前提（モデル制約）が依然有効か判定**: ADR 本文の Context / Decision を読み、新モデルでも同じ制約が成立するか確認する
+3. **不要化・閾値変更の候補をリストアップ**: 制約が緩和された設計要素は、[Superseded / Amended の手続き](#廃止上書き手順)で更新候補とする
+4. **「該当 ADR なし」カテゴリは ADR 起票を検討**: 既存スキル/エージェントの該当箇所を洗い出し、ADR 化要否を [粒度判定基準](#粒度判定基準) で判定する


### PR DESCRIPTION
## 概要

モデル制約に明示言及する ADR 11 件を、設計要素別 8 カテゴリに索引化したセクションを `docs/adr/README.md` 末尾に追加した。モデル更新時に「どのガードレールを見直すか・どの閾値を変更しうるか」を即座に判断できる起点を一箇所に集約する。

Closes #86

## 経緯（再スコープ）

元案は各 SKILL.md に `## 設計根拠` セクションを追加する形だったが、横断調査の結果以下の問題が判明したため ADR ハブ化へ再スコープした:

- スキル/エージェント/参照ファイル群には「モデル制約への対処」が広範に分散（約 88 件、ADR 14 件で議論済み・うち明示 11 件）
- SKILL.md 本体への追記は CLAUDE.md「token 規律（SKILL.md 170 行目安）」と衝突
- 既に ADR で議論済みの内容を SKILL.md にも書くと二重管理になりドリフトを誘発

ADR を単一の真実源とし、README から設計要素別に逆引きできる索引を作るのが最小コスト・最大効果と判断した。

## 変更内容

`docs/adr/README.md` 末尾に新セクション「モデル制約由来の設計判断インデックス」を追加。

### 8 カテゴリ別の ADR 割当（レビュー反映後）

| カテゴリ | 該当 ADR 数 | 内訳 |
|---|---|---|
| 自己評価バイアス対策 | 3 | ADR-20260406 / 407 / 602-2 |
| コンテキスト膨張・トークン効率対策 | 4 | ADR-20260525 / 525-2 / 604 / 606-2 |
| 早期収束・手抜き対策 | 1 | ADR-20260604 |
| 指示忠実性低下対策 | 3 | ADR-20260602-principles / 606-2 / 606-protection |
| ハルシネーション対策 | 0 | **ADR 化候補**（スキル定義側で対処） |
| 並列数・モデル指定の固定 | 0 | **ADR 化候補**（スキル定義側で対処） |
| モデル/ハーネスの固有挙動への対処 | 3 | ADR-20260421 / 525 / 601 |
| スコープ逸脱対策（ツール制限） | 0 | **ADR 化候補**（エージェント定義側で対処） |

複数カテゴリにまたがる ADR は重複記載した（索引利便性 > 簡潔性）。各カテゴリでの説明文はカテゴリの焦点に合わせて差別化している。

### 見直しフロー

カテゴリ順に ADR を再評価する 4 ステップのフローを併設:

1. 設計要素別に該当 ADR を引く
2. 各 ADR の前提（モデル制約）が依然有効か判定
3. 不要化・閾値変更の候補をリストアップ（Superseded / Amended 手続きへ）
4. 「該当 ADR なし」カテゴリは ADR 起票を検討

## AC 充足

| AC | 結果 | 検証方法 |
|---|---|---|
| 「モデル制約由来の設計判断インデックス」セクション存在 | OK | `grep -n "^## モデル制約由来" docs/adr/README.md` で存在確認 |
| 明示言及 11 件の ADR を索引化 | OK | 11 件全て 1 回以上参照（うち 3 件は 2 カテゴリにまたがり重複記載） |
| 設計要素カテゴリで分類・リンク可能 | OK | 8 カテゴリ + 見直しフローで `### ` ヘッダ 9 個 |
| モデル更新時の見直しフロー記載 | OK | 「### モデル更新時の見直しフロー」存在 |
| 既存 ADR 本文無変更 | OK | `git diff --name-only docs/adr/` の README.md 以外のヒット 0 件 |

## レビュー反映履歴

初版（コミット `f021779`）に対するレビュー指摘 4 件を、コミット `65a5eae` で修正:

| 指摘 | 修正内容 |
|---|---|
| ADR-20260406「禁じ」は本文より強い | Decision 第 3 項で簡易パスは自力導出許容と再確認。要約を「正規パスでは...排し...（簡易パスでの自力導出は許容）」へ |
| ADR-20260601「AI暴走」「自己評価バイアス」は本文不在の補完語 | 要約を「Command 属性として追加せず、責任分担マトリクスで表現することで、ドメインモデル層と Explanation 層を分離」へ訂正。カテゴリも「モデル/ハーネスの固有挙動への対処」へ移動 |
| ADR-20260602-2「検証能力成熟時のみ」は Why を What に格上げした誤読 | L3 縮退形の純粋定義に戻して「L3 を AI が提案から確定まで自律実行する縮退形として定義する規約を固定」へ |
| ADR-20260604 が 2 カテゴリで同一説明文 | コンテキスト膨張側＝「重複読み込み・ドリフト抑制」、早期収束側＝「判定基準乖離による早期妥当判定バイアス防止」と差別化 |

## 対象外（別 Issue 候補）

- SKILL.md / agents / references 本体への設計根拠セクション追加（token 規律と衝突するため不採用）
- 暗黙該当 ADR（モデル制約由来と読めるが本文に明示記述のないもの）の補完追記
- フロントマターへの `rationale:` フィールド追加（案 B）
- 「該当 ADR なし」3 カテゴリの ADR 起票（見直しフロー Step 4 で検討）

## 関連

- Issue #86 本文（再スコープ後）: <https://github.com/kuchita-el/claude-shared-skills/issues/86>
