### PR TITLE
chore: bump dev-workflow plugin version to 0.6.2

### DIFF
--- a/plugins/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "dev-workflow",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Claude Code向けの汎用開発ワークフロースキル集。Issue管理・開発ループ・PR レビュー・依存関係チェック等を提供する。"
 }


### PR DESCRIPTION
## Summary

- dev-workflow プラグインのバージョンを `0.6.1` → `0.6.2` にバンプ

直近のバグ修正（PR #330, #332）を反映したパッチリリース:
- refine-issue: 論点識別子を `B{n}` から `Q{n}` に変更
- refine-issue: ブロッカーセクションの命名衝突を解消（未解決論点に統一）

## Test plan

- [ ] plugin.json のバージョンが `0.6.2` であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
