### PR TITLE
feat: reflect スキル Capture 段を実装（#346）

### DIFF
--- a/plugins/growth/skills/reflect/SKILL.md
+++ b/plugins/growth/skills/reflect/SKILL.md
@@ -29,11 +29,12 @@ allowed-tools:
 **リポジトリルートと project-id**:
 
 ```bash
-git rev-parse --git-common-dir
+git rev-parse --path-format=absolute --git-common-dir
 ```
 
-このコマンドは worktree・通常リポジトリの両方で共通の `.git` ディレクトリの絶対パスを返す（例: `/home/user/myproject/.git`）。末尾の `/.git` を除いたパスをリポジトリルートとし、全 `/` を `-` に置換して `<project-id>` とする（例: `-home-user-myproject`）。
+このコマンドは worktree・通常リポジトリの両方で共通の `.git` ディレクトリの**絶対パス**を返す（例: `/home/user/myproject/.git`）。`--path-format=absolute` は Git 2.31 以降で利用可能。末尾の `/.git` を除いたパスをリポジトリルートとし、全 `/` を `-` に置換して `<project-id>` とする（例: `-home-user-myproject`）。
 
+> `--git-common-dir` 単体は CWD に応じて相対パスを返す場合があるため `--path-format=absolute` を必ず併用する。
 > `git rev-parse --show-toplevel` は worktree 内では worktree 固有パスを返すため使用しない。
 
 **session UUID**:

--- a/plugins/growth/skills/reflect/SKILL.md
+++ b/plugins/growth/skills/reflect/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: 現セッション会話履歴（session jsonl）から予測誤差シグナル（訂正・ツール拒否・反復試行・期待違反）を検知し、解釈を加えない生観察として個人ローカル store（`~/.claude/projects/<project-id>/growth/captures.md`）に記録する。判断は後回しにし、「何が起きたか」のみを記す。セッション中の予測誤差を貯めたいとき・growth プラグインの学習ループを手動で起動したいときに明示起動する（Phase 1）。
+description: reflect は現セッション会話履歴（session jsonl）から予測誤差シグナル（訂正・ツール拒否・反復試行・期待違反）を検知し、解釈を加えない生観察として個人ローカル store に記録する。判断は後回しにし、「何が起きたか」のみを記す。セッション中の予測誤差を貯めたいとき・growth プラグインの学習ループを手動で起動したいときに明示起動する（Phase 1）。
 allowed-tools:
   - Read
   - Write
@@ -7,7 +7,6 @@ allowed-tools:
   - Bash(date *)
   - Bash(printenv *)
   - Bash(git rev-parse *)
-  - Bash(cat *)
   - Bash(grep *)
 ---
 
@@ -30,10 +29,12 @@ allowed-tools:
 **リポジトリルートと project-id**:
 
 ```bash
-git rev-parse --show-toplevel
+git rev-parse --git-common-dir
 ```
 
-取得したパス（例: `/home/user/myproject`）の全 `/` を `-` に置換して `<project-id>` とする（例: `-home-user-myproject`）。
+このコマンドは worktree・通常リポジトリの両方で共通の `.git` ディレクトリの絶対パスを返す（例: `/home/user/myproject/.git`）。末尾の `/.git` を除いたパスをリポジトリルートとし、全 `/` を `-` に置換して `<project-id>` とする（例: `-home-user-myproject`）。
+
+> `git rev-parse --show-toplevel` は worktree 内では worktree 固有パスを返すため使用しない。
 
 **session UUID**:
 
@@ -54,13 +55,17 @@ date -u +"%Y-%m-%dT%H:%M:%SZ"
 - store パス: `~/.claude/projects/<project-id>/growth/captures.md`
 - jsonl パス: `~/.claude/projects/<project-id>/<session-UUID>.jsonl`
 
+> jsonl の保存場所は Claude Code の内部仕様に依存する。不明な場合は `~/.claude/projects/<project-id>/` 配下を確認すること。
+
 ### Step 2: jsonl 読取とシグナル検知
 
-jsonl を読み取り、4種のシグナルを**再現率寄り**（拾い過ぎ許容）で走査する。確実なものより多めに拾い、精査は Distill に委ねる。
+**ファイル存在確認**:
 
-```bash
-cat ~/.claude/projects/<project-id>/<session-UUID>.jsonl
-```
+Read ツールで jsonl パスを読み取る。ファイルが存在しない・読み取れない場合は「セッションログが見つかりません（確認パス: ...）」と報告して終了する。ファイルが存在しない場合でもエントリを store に書かない。
+
+**シグナル走査**:
+
+jsonl の内容（JSON Lines 形式）から4種のシグナルを**再現率寄り**（拾い過ぎ許容）で走査する。確実なものより多めに拾い、精査は Distill に委ねる。
 
 必要に応じてキーワードで絞り込む（例）:
 
@@ -69,7 +74,7 @@ grep -i "denied\|permission\|拒否\|訂正\|違う\|error\|再試行" \
   ~/.claude/projects/<project-id>/<session-UUID>.jsonl
 ```
 
-各メッセージ（JSON Lines 形式）から以下のシグナルを識別する:
+各メッセージから以下のシグナルを識別する:
 
 | シグナル | 識別の手掛かり |
 |---|---|
@@ -77,6 +82,8 @@ grep -i "denied\|permission\|拒否\|訂正\|違う\|error\|再試行" \
 | `ツール拒否` | ツール呼び出しが拒否された記録（denied、permission denied、hook ブロック等の痕跡） |
 | `反復試行` | 同一目的の操作を複数回繰り返した記録（同じコマンド・同じ修正が連続する等） |
 | `期待違反` | 予測した結果と実際の結果が食い違った痕跡（エラー後の対処、「想定と異なる」等の発話） |
+
+> `客観痕跡`（git revert・CI 失敗等）は store のシグナル値域に含まれるが Phase 1 では投入しない（取得は Phase 3）。
 
 **0件の場合**: 捕捉ゼロを報告して終了する（空エントリを store に書かない）。
 

--- a/plugins/growth/skills/reflect/SKILL.md
+++ b/plugins/growth/skills/reflect/SKILL.md
@@ -1,0 +1,133 @@
+---
+description: 現セッション会話履歴（session jsonl）から予測誤差シグナル（訂正・ツール拒否・反復試行・期待違反）を検知し、解釈を加えない生観察として個人ローカル store（`~/.claude/projects/<project-id>/growth/captures.md`）に記録する。判断は後回しにし、「何が起きたか」のみを記す。セッション中の予測誤差を貯めたいとき・growth プラグインの学習ループを手動で起動したいときに明示起動する（Phase 1）。
+allowed-tools:
+  - Read
+  - Write
+  - Bash(mkdir *)
+  - Bash(date *)
+  - Bash(printenv *)
+  - Bash(git rev-parse *)
+  - Bash(cat *)
+  - Bash(grep *)
+---
+
+# reflect（Capture）
+
+現セッション会話履歴から予測誤差シグナルを検知し、生観察を個人ローカル store へ記録する。
+
+## 目的・原則
+
+- **目的**: 予測誤差（驚き）の痕跡を「判断前」の状態で保存する。蒸留・候補化は Distill が担う。
+- **生記録性**: observation には「何が起きたか」のみを記録する。原因分析・対策・分類・昇格判断を書かない。解釈は Distill に委ねる（DESIGN.md 原理3・Capture 原則「判断は後回し」）。
+- **Phase 1 スコープ**: 痕跡ソースは現セッションの session jsonl のみ。明示起動のみ（hook 自発化は Phase 3）。`客観痕跡` は store のシグナル値域に含むが本段では投入しない。
+
+## 手順
+
+### Step 1: 入力収集
+
+以下を順に取得する。
+
+**リポジトリルートと project-id**:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+取得したパス（例: `/home/user/myproject`）の全 `/` を `-` に置換して `<project-id>` とする（例: `-home-user-myproject`）。
+
+**session UUID**:
+
+```bash
+printenv CLAUDE_CODE_SESSION_ID
+```
+
+> Phase 3（hook 自発化）移行時は `CLAUDE_CODE_CHILD_SESSION=1` 環境下での session UUID 解決を要再確認。
+
+**timestamp**（ISO 8601 UTC）:
+
+```bash
+date -u +"%Y-%m-%dT%H:%M:%SZ"
+```
+
+**パスの組み立て**:
+
+- store パス: `~/.claude/projects/<project-id>/growth/captures.md`
+- jsonl パス: `~/.claude/projects/<project-id>/<session-UUID>.jsonl`
+
+### Step 2: jsonl 読取とシグナル検知
+
+jsonl を読み取り、4種のシグナルを**再現率寄り**（拾い過ぎ許容）で走査する。確実なものより多めに拾い、精査は Distill に委ねる。
+
+```bash
+cat ~/.claude/projects/<project-id>/<session-UUID>.jsonl
+```
+
+必要に応じてキーワードで絞り込む（例）:
+
+```bash
+grep -i "denied\|permission\|拒否\|訂正\|違う\|error\|再試行" \
+  ~/.claude/projects/<project-id>/<session-UUID>.jsonl
+```
+
+各メッセージ（JSON Lines 形式）から以下のシグナルを識別する:
+
+| シグナル | 識別の手掛かり |
+|---|---|
+| `訂正` | ユーザーが当方の出力・提案を修正した発話（「違う」「〜ではなく〜」「〜を使え」等）または当方が誤りを認めた発話 |
+| `ツール拒否` | ツール呼び出しが拒否された記録（denied、permission denied、hook ブロック等の痕跡） |
+| `反復試行` | 同一目的の操作を複数回繰り返した記録（同じコマンド・同じ修正が連続する等） |
+| `期待違反` | 予測した結果と実際の結果が食い違った痕跡（エラー後の対処、「想定と異なる」等の発話） |
+
+**0件の場合**: 捕捉ゼロを報告して終了する（空エントリを store に書かない）。
+
+### Step 3: 生観察の生成
+
+Step 2 で検知した各シグナルについて observation を生成する。
+
+**記述対象**: 「何が起きたか」のみ。ユーザーの発話・ツール結果・当方の応答から観察できる事実を記述する。  
+**記述禁止**: 原因・対策・分類・改善提案・昇格判断を含めない。
+
+例:
+```
+ユーザーが「git checkout ではなく git restore を使え」と訂正した。
+当方はファイル復元に git checkout を提案していた。
+```
+
+### Step 4: store 書き込み
+
+**ディレクトリ作成**（存在しない場合）:
+
+```bash
+mkdir -p ~/.claude/projects/<project-id>/growth/
+```
+
+**エントリ形式**（1観察 = 1エントリ）:
+
+```
+## <timestamp>
+- signal: <シグナル種別>
+- session: <session-UUID>
+- status: unprocessed
+
+<observation 本文（複数行可）>
+```
+
+`status` は常に `unprocessed` で書き込む（既存エントリの status を変更しない）。
+
+**書き込み方式**:
+
+- **store 未存在**: Write ツールで新規作成する。
+- **store 存在**: Read ツールで既存内容を全文読み取り、末尾に新規エントリを連結して Write ツールで全書換する。既存エントリ（`promoted` 含む）は保持する。
+
+複数シグナルを検知した場合、各エントリを別の `## <timestamp>` 見出しで記録する（1観察 = 1エントリ）。
+
+## 完了報告
+
+書き込んだエントリ数・各シグナル種別・store パスを報告する。
+
+```
+3件の観察を記録しました。
+- 訂正 × 1
+- ツール拒否 × 2
+store: ~/.claude/projects/-home-user-myproject/growth/captures.md
+```


### PR DESCRIPTION
## 概要

growth プラグインに `reflect` スキルの Capture 段を実装する。現セッション会話履歴（session jsonl）から予測誤差シグナルを検知し、解釈を加えない生観察として個人ローカル store に記録する。

- `plugins/growth/skills/reflect/SKILL.md` を新規作成
- `plugins/growth/skills/.gitkeep` を削除（スキル実体が入ったため）

## 対応 Issue AC

| AC | 内容 | 状態 |
|---|---|---|
| AC1 | SKILL.md が存在し、frontmatter（description・allowed-tools）と Capture 手順を含む | ✅ |
| AC2 | 4シグナル（訂正・ツール拒否・反復試行・期待違反）の検知手順が定義されている | ✅ |
| AC3 | 検知結果が #345 確定の個人ローカル store 形式に従って書き込まれる | ✅ |
| AC4 | Capture 段が解釈・分類・昇格判断を含まないことが手順上明示されている | ✅ |
| AC5 | allowed-tools が手順内で実際に使用するツールのみを列挙している | ✅ |

## 主要設計決定

- **会話履歴アクセス**: session jsonl 直読（Phase 3 フック移行時の連続性のため。Claude 文脈内解析は hook 経由では使えない）
- **project-id 解決**: `git rev-parse --git-common-dir` で main リポジトリルートへ正規化（worktree 分裂防止）
- **シグナル検知精度**: 再現率寄り（拾い過ぎ許容。精査は Distill に委ねる）

## セルフレビュー実施済み

- **周回数**: 1周
- **修正ブロッカー数**: 3件

### 修正した指摘

| 重大度 | 指摘 | 対応内容 | コミット |
|---|---|---|---|
| Critical | `git rev-parse --show-toplevel` は worktree 内で worktree 固有パスを返し、J3（worktree 分裂防止）の意図と逆の動作をする | `git rev-parse --git-common-dir` に変更し、main リポジトリの `.git` パスから親ディレクトリをルートとして取得する手順に修正 | f8f5b23 |
| Important | jsonl 未存在時に `cat` エラー → シグナル0件扱い → 「捕捉ゼロ」と誤報告するサイレント偽陰性 | Step 2 冒頭に存在確認ステップを追加。ファイルが読み取れない場合は「セッションログが見つかりません」として終了する | f8f5b23 |
| Important | `Bash(cat *)` は CLAUDE.md「cat を Bash で使わず Read ツールを使う」規約違反 | Step 2 の jsonl 読取を `Read` ツールに置換し、`Bash(cat *)` を allowed-tools から削除 | f8f5b23 |

Closes #346
