### PR TITLE
docs(claude): 陳腐化した Skill Categories テーブルを削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,16 +44,6 @@ allowed-tools:
 
 **`allowed-tools` の原則**: 必要最小限のツールのみ許可する。Bashは `Bash(コマンドパターン*)` でワイルドカード指定し、スキルが実行できるシェルコマンドを制限する。
 
-### Skill Categories
-
-| カテゴリ | スキル |
-|---|---|
-| Issue管理 | `create-issue`, `refine-issue` |
-| 計画 | `plan-issue` |
-| 実装 | `implementation` |
-| ドメイン設計 | `event-storming` |
-| 依存関係 | `dependency-check` |
-
 ### DoR Framework
 
 `create-issue`（作成時の前倒し充足）と `refine-issue`（作成後の精査）が同一のDoR定義を共有参照する。読み込み優先順位:


### PR DESCRIPTION
## 概要

`CLAUDE.md` の `### Skill Categories` テーブルを削除する。

このテーブルは実在するスキルの一覧として既に不正確であり、常時読み込まれるファイルから誤った案内を配っている状態にある。

## 問題

テーブルが挙げるスキルは 6 件:

`create-issue` / `refine-issue` / `plan-issue` / `implementation` / `event-storming` / `dependency-check`

一方 `plugins/dev-workflow/skills/` に実在するのは 8 件で、**2 件が記載から漏れている**:

| スキル | テーブル記載 | 実在 |
|---|---|---|
| `domain-modeling` | ✗ なし | ✓ |
| `manage-adr` | ✗ なし | ✓ |

漏れは一度きりの事故ではない。`domain-modeling` 追加時と `manage-adr` 追加時（#502）の**二度、同じ更新漏れが起きている**。テーブルを維持する限り、スキルを追加するたびに二重更新が必要で、漏れるたびに乖離が広がる。

## 方針

この情報は `ls plugins/dev-workflow/skills/` で導出でき、各スキルの説明は `SKILL.md` の `description` に単一の出典を持つ。`CLAUDE.md` に写しを置く必然性がない。

導出可能な写しを除去し、出典を一箇所に保つ。

## 影響

- 削減は約 45 トークン/セッションと小さい。**主目的はトークン削減ではなく正確性の維持**
- テーブルが挙げていた 6 件は全て実在するため、削除によって失われる正しい情報はない
- カテゴリ分類（Issue管理／計画／実装／ドメイン設計／依存関係）という切り口は失われる。ただしこの分類は他のどこからも参照されておらず、各スキルの `description` が用途を説明している

## 補足

本 PR は `/doctor` による設定診断の一環で検出した。同診断では `~/.claude/CLAUDE.md`（dotfiles 側）からも、プロンプトキャッシュの TTL に関する陳腐化した記述を削除している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
