### PR TITLE
docs(adr): ADR-20260716 / ADR-20260716-2 を承認済み・有効へ更新

### DIFF
--- a/docs/adr/ADR-20260716-2-completion-judgment-inquiry-value-range.md
+++ b/docs/adr/ADR-20260716-2-completion-judgment-inquiry-value-range.md
@@ -1,6 +1,6 @@
 ---
-status: 提案中
-validity:
+status: 承認済み
+validity: 有効
 superseded-by:
 ---
 
@@ -8,8 +8,8 @@ superseded-by:
 
 ## Status（承認軸／有効性軸）
 
-- **承認軸**（`status`）: `提案中`
-- **有効性軸**（`validity`）: 空（`提案中` のため）
+- **承認軸**（`status`）: `承認済み`（PR #502 のレビュー2巡を経て承認）
+- **有効性軸**（`validity`）: `有効`
 - **`superseded-by`**: 空
 
 ## Context

--- a/docs/adr/ADR-20260716-inquiry-skill-question-governance.md
+++ b/docs/adr/ADR-20260716-inquiry-skill-question-governance.md
@@ -1,6 +1,6 @@
 ---
-status: 提案中
-validity:
+status: 承認済み
+validity: 有効
 superseded-by:
 ---
 
@@ -8,8 +8,8 @@ superseded-by:
 
 ## Status（承認軸／有効性軸）
 
-- **承認軸**（`status`）: `提案中`
-- **有効性軸**（`validity`）: 空（`提案中` のため）
+- **承認軸**（`status`）: `承認済み`（PR #502 のレビュー2巡を経て承認）
+- **有効性軸**（`validity`）: `有効`
 - **`superseded-by`**: 空
 
 ## Context


### PR DESCRIPTION
## 背景

PR #502 でマージした ADR-20260716 / ADR-20260716-2 が、`status: 提案中` / `validity` 空のまま main に入っている。レビューは2巡して完了し PR もマージされているため、front-matter が実態と食い違っている。

`template.md` は「状態は本ファイル冒頭の front-matter が唯一の権威」と定めるため、この食い違いは記録上の誤りにあたる。

## 調査結果

規約が定める手順は以下であり、本件の #502（起票）→ 本 PR（承認後の更新）はこの手順に沿っている。

- `template.md:2` — front-matter の既定値が `status: 提案中`
- `README.md:134-135` — 「1. 新 ADR を起票する（front-matter は `status: 提案中` で開始） / 2. **承認後**、新 ADR の front-matter を `status: 承認済み` / `validity: 有効` に**更新する**」
- `README.md:47` — 「`提案中` をスキップして直接 `承認済み` に到達する経路は持たない」
- `scripts/lint-adr.sh:43` — `status=提案中` かつ `validity` 空 かつ `superseded-by` 空 を「起票」として明示的に合法化

一方、リポジトリの実運用はこの手順から外れている。

- 現在 `status: 提案中` の ADR は本件の2本のみ。他に該当なし
- 直近の ADR-20260713 は新設コミット（`284d33c`）の時点で既に `承認済み` / `有効`
- `git log -S"status: 承認済み" --all -- docs/adr/` の結果は一括移行・退役処理・分割のみで、**`提案中` → `承認済み` へ遷移したコミットは履歴に存在しない**

すなわち規約の定める2段階の遷移は一度も実行されておらず、全 ADR が `承認済み` で直接 commit されてきた。これは規約が守られてこなかったことを示すものであり、規約側を実運用に合わせるべき根拠ではない。`README.md:47` の「即承認のケースは『提案 → 承認』を連続実行として扱う」は、連続実行であっても2つの遷移を経ることを求めており、「最初から `承認済み` で commit してよい」とは読めない。

## 本件で生じた手続き上の誤り

#502 は `提案中` で起票した点までは規約どおりだが、レビュー完了後に `README.md:135` の第2手順（承認後の front-matter 更新）を実行しないままマージした。そのため main に `提案中` の ADR が存在する状態が生じ、本 PR がその後追いになっている。

本来は #502 のレビューが完了した時点で同一 PR 内で front-matter を更新し、`承認済み` の状態でマージすべきだった。そうすれば本 PR は不要であり、main が `提案中` を持つ窓も生じない。

## 変更内容

ADR-20260716 / ADR-20260716-2 の front-matter を `status: 承認済み` / `validity: 有効` へ更新し、本文の `## Status` セクションを front-matter と整合させる。

## 検証

`bash scripts/lint-adr.sh docs/adr` を実行。**本 PR による新規違反はゼロ**（出力は変更前と同一）。

## 本 PR では対応しない既存の問題

lint が検出する3件はいずれも本 PR の変更と無関係であり、変更前後で出力が一致する。

1. **`docs/adr/index.md` が存在しない**
2. `ADR-20260531-2` の `superseded-by` が後継 `ADR-20260602` を指していない
3. `ADR-20260511` の `superseded-by` が後継 `ADR-20260711-3` を指していない

とくに 1 については、本 PR で `validity: 有効` の ADR が2本増えるため index 生成を検討したが、**見送る**。`validity: 有効` を持つ ADR は 40本中6本にとどまり（32本が2軸 front-matter へ未移行のまま `## Status` セクションのみの旧形式で残っている）、現時点で index を生成すると 6/40 しか掲載されず「リポジトリに ADR が6本しかない」と誤読させる。index 生成は未移行32本の解消（#476 が追跡）の完了後に行うのが妥当と判断した。

2 と 3 は退役 ADR の front-matter に触る修正であり、`README.md`「`上書き済み` / `廃止済み` に退役した ADR は凍結された歴史的成果物として編集しない」（ADR-20260711-3 決定3）と衝突しうるため判断が必要。別 Issue での対応を提案する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
