### PR TITLE
docs(adr): 有効ADRの Related 退役参照を後継へ張替える（#491）

### DIFF
--- a/docs/adr/ADR-20260402-workflow-design-v2-structure.md
+++ b/docs/adr/ADR-20260402-workflow-design-v2-structure.md
@@ -51,7 +51,7 @@ validity: 有効
 
 Amended by: ADR-20260602-principles-rationale-hub（責務定義 facet を改訂。本ADRは Accepted 維持・残り5決定は有効。初版 amend は ADR-20260531-2 だが同 ADR は ADR-20260602 に Superseded されたため、現行の amend 元は ADR-20260602）
 
-Related: ADR-20260511-technical-decision-aggregate-foundation（ADR採番方式は本ADRの旧記述を上書き）
+Related: ADR-20260711-3-adr-two-axis-status-validity-model（ADR採番方式 `ADR-YYYYMMDD[-N]` は本ADRの旧記述を上書き。同方式は上書き済みの ADR-20260511 が定めたもので、決定8「採番方式・配置（ADR-20260511 から不変で引き継ぐ）」として現行 ADR へ不変のまま引き継がれた）
 
 関連Issue: PR #89（workflow-design.md v2 改訂本体）、#94（Delivery→Discovery フィードバックループ）、#95（spec.md ライフサイクル）、#100（AIエラー時の再開・引き継ぎ）
 

--- a/docs/adr/ADR-20260601-autonomy-approval-gate-alignment.md
+++ b/docs/adr/ADR-20260601-autonomy-approval-gate-alignment.md
@@ -41,6 +41,6 @@ Issue #232 の確定設計判断①で **非重複形** の採用が決定され
 ## 関連ADR
 
 - Related: ADR-20260421-agent-modeling-principle（ドメインモデル層の決定。本 ADR は Explanation 層で非重複に補完する）
-- Related: ADR-20260511-technical-decision-aggregate-foundation（承認ゲート二段表現の実装済み雛形）
+- Related: ADR-20260711-3-adr-two-axis-status-validity-model（承認ゲート二段表現の実装済み雛形。二段は決定1 の承認軸 `提案中`→`承認済み` として現行 ADR にある。上書き済みの ADR-20260511 が英文4状態で定めていたものを、同決定が日本語の承認軸へ置き換えた）
 
 関連Issue: #237（本Issue）, #232（親トラッカー）, #238（自律度モデル L0–L3 規約 ADR）, #239（判定ルーブリック）, #240（ゲート二段表現規約／記法拡張）, #227（保全媒体、CLOSED）

--- a/docs/adr/ADR-20260602-2-autonomy-ladder-convention.md
+++ b/docs/adr/ADR-20260602-2-autonomy-ladder-convention.md
@@ -62,6 +62,6 @@ L0–L3 を固定的な序列として扱うと、運用実態を取り違える
 
 - Related: ADR-20260601-autonomy-approval-gate-alignment（承認ゲート軸の整合方針。本 ADR はその留保事項である L0–L3 正式定義・二段方針・縮退形を確定する規約 ADR）
 - Related: ADR-20260421-agent-modeling-principle（自律度をドメインモデルへ持ち込まないドメイン構造層の決定。本 ADR は Explanation 層の規約であり層が異なる）
-- Related: ADR-20260511-technical-decision-aggregate-foundation（提案→承認二段の実装済み雛形＝Proposed→Accepted ライフサイクル）
+- Related: ADR-20260711-3-adr-two-axis-status-validity-model（提案→承認二段の実装済み雛形＝決定1 の承認軸 `提案中`→`承認済み`。上書き済みの ADR-20260511 は同じ二段を `Proposed / Accepted / Deprecated / Superseded` の英文4状態ライフサイクルの一部として定めていたが、同決定がこれを日本語の承認軸へ置き換えた）
 
 関連Issue: #238（本Issue）, #232（親トラッカー）, #237（整合方針、CLOSED）, #239（判定ルーブリック）, #240（ゲート二段表現規約／記法拡張）

--- a/docs/adr/ADR-20260711-4-capture-timestamp-identity-rule.md
+++ b/docs/adr/ADR-20260711-4-capture-timestamp-identity-rule.md
@@ -53,7 +53,7 @@ growth の生観察 store（`captures.md`）は各観察を `## <timestamp>` 見
 
 ## 関連ADR
 
-- Related: ADR-20260711-2-distill-highwater-cursor（カーソル highwater モデル。本 ADR はその依拠する見出しキーの一意性 facet を補完する。カーソルモデル本体は不変）
+- Related: ADR-20260712-captures-bounded-retention-aging（カーソル highwater モデルの現行の住処。本 ADR はその依拠する見出しキーの一意性 facet を補完する。カーソルモデル本体は不変で、決定2 が上書き済みの ADR-20260711-2 のカーソル機構〔store レベルの単一 high-water mark・guarantee-once・provenance による重複排除・欠損時は先頭を既定〕を restate して引き継いだ）
 - Related: ADR-20260713-captures-stateless-candidate-side-state（captures 無状態化。provenance ＋カーソルによる処理源選択の土台。決定1・3 の現行の住処。ADR分割〔#488〕以前は上書き済みの ADR-20260711-store-state-model-captures-stateless を指していた）
 
 関連Issue: #434, #459, #451, #470


### PR DESCRIPTION
## 概要

有効な ADR（`validity: 有効`）の `## 関連ADR` 節にある `Related:` 行のうち、参照先識別子が退役 ADR（`上書き済み`）を指すものを全件特定し、退役 ADR の front-matter `superseded-by` が指す後継へ張り替えた。参照先識別子は後継へ置換し、退役 ADR の識別は括弧内の経緯説明へ移した（Issue の決定1＝移設。併記は採らない）。

Closes #491

## 起票時の前提が誤っていた点（重要）

Issue は「真の該当は既知3件で全件であり、追加の綻びは存在しないことを確認済み」としていたが、**実装時の全件走査で該当は4件**だった。4件目は `ADR-20260402-workflow-design-v2-structure.md:54` の `Related: ADR-20260511-…`。

見落としの機序も特定した。既知3件はいずれもハイフンバレット付きの `- Related:` だが、4件目のみバレットなしの `Related:` である。Issue の決定2 が判定単位を「`- Related:` 直後の ADR 識別子」と**バレット込みで**明文化しているため、その字義通りの走査はバレットなし行を構造的に検査対象外とする（実データにバレットなし `Related:` 行は12行・11ファイル存在する）。この相関は完全一致だった。是正しないまま AC5 の機械スキャンを実行すると、綻びを残したまま「0 件」を報告する偽陰性になっていた。

本 PR の作業中に Issue #491 本文の前提記述と AC4 を4件へ訂正済み（判断 J1）。

## 変更内容

| 元 ADR（有効） | 行 | 旧参照先（退役） | 新参照先（後継） | facet |
|---|---|---|---|---|
| `ADR-20260402` | 54 | `ADR-20260511` | `ADR-20260711-3` | ADR採番方式 |
| `ADR-20260601` | 44 | `ADR-20260511` | `ADR-20260711-3` | 承認ゲート二段 |
| `ADR-20260602-2` | 65 | `ADR-20260511` | `ADR-20260711-3` | 承認ゲート二段 |
| `ADR-20260711-4` | 56 | `ADR-20260711-2` | `ADR-20260712` | カーソル機構 |

括弧内の説明は、識別子の置換だけで済ませず後継の内容へ整合させた（AC3）。とくに `ADR-20260602-2:65` は元が「提案→承認二段の実装済み雛形＝Proposed→Accepted ライフサイクル」であり、識別子のみを機械置換すると「`ADR-20260711-3` ＝ `Proposed→Accepted`」と主張する形になる。`ADR-20260711-3` 決定1 はこの英文4状態を日本語の承認軸（`提案中` / `承認済み` / `却下`）へ置き換えているため、そのままでは**本 Issue が潰そうとしているものと同型の新たなドリフト**を生む。括弧内の語彙を承認軸へ改稿し、英文状態名は「上書き済みの ADR-20260511 が定めていた」経緯としてのみ残した。

## 決定した判断（plan 段階でユーザー承認済み）

| 観点 | 決定 |
|---|---|
| J1 | 4件目をスコープに含めて修正し、Issue 本文と AC4 を4件へ訂正する |
| J2 | 走査はバレット任意（`^[[:space:]]*-?[[:space:]]*Related:`）とする。決定2 の趣旨は「判定単位は行全体でなく参照先識別子」であり、バレットの有無は論点ではない |
| J3 | `scripts/lint-adr.sh` への恒久検査追加はしない（Issue の OUT 宣言を正とする）。#474 系へ送る |
| J4 | 解決不能な略記 stem は fail-safe（違反として報告）とし、人手で評価・記録する |

## 対応 Issue AC

- AC1
- AC2
- AC3
- AC4
- AC5
- AC6

## 検証結果

- **AC1**: 走査で live→退役を4件列挙（バレットなしの `ADR-20260402:54` を含む）。既に是正済みの `ADR-20260711-4:57`（退役 ADR 名が括弧内の経緯説明にのみ出現）は決定2 により偽陽性として計上されない。
- **AC5**: 張替え後の再走査で live→退役 **0 件**。
- **AC5 の解決不能2件（J4=(A) の fail-safe 報告に対する人手評価）**: `ADR-20260606-protection-priority-ladder.md:65` の `ADR-20260602` は前方一致が2ファイルに当たる曖昧参照だが、文脈から実体は `ADR-20260602-principles-rationale-hub`（`validity: 有効`）。同 `:66` の `ADR-20260602-2` は略記で、実体は `ADR-20260602-2-autonomy-ladder-convention`（`validity: 有効`）。**いずれも live→退役の綻びではない**。走査が違反報告するのは設計どおりで、暗黙に「対象外＝合格」へ畳んでいない（#476 AC6 の先例と整合）。
- **AC6**: `git diff main...HEAD` の変更行8行が全て `## 関連ADR` 節内の `Related:` 行。`## Decision` の差分 0 行、`Amends:` / `Amended by:` の凍結参照に差分なし、`scripts/` に差分なし。
- **回帰**: `bash scripts/lint-adr.sh docs/adr` が exit 0 を維持（ベースラインと同一）。

走査は検証用スクリプトで実施した（J3=(A) によりリポジトリへはコミットしていない）。

## セルフレビュー実施済み

レビュー: 1周実施、ブロッカー0件

独立レビュアーが一次情報（後継 ADR の決定本文・front-matter・`git diff`）で各 AC を再検証し、ブロッカーなしと判定した。

### 修正した指摘

| 重大度 | 指摘 | 対応内容 | コミット |
|---|---|---|---|
| 改善提案 | `ADR-20260602-2:65` の括弧内が「`Proposed / Accepted` の英文4状態」と書きながら2状態しか示さず、「4状態＝Proposed/Accepted」と誤読する余地がある | AC3 が統べる括弧内語彙そのものであり精度を優先。`ADR-20260711-3` 決定1 自身の表記に合わせて `Proposed / Accepted / Deprecated / Superseded` を全列挙し、「英文4状態ライフサイクルの一部として定めていた」へ改めた | 1740bf5（amend 済み） |

### 改善提案（未対応・レビュアー判断に委ねる）

- **Issue #491 本文のスコープ「IN」節と「参考: 実現の手がかり」節に「既知の3件」という旧記述が残存している**。plan の Task 2 は訂正範囲を「背景・課題の前提記述」と「AC4」の2箇所に明示的に限定しており（決定1・決定2・スコープ IN/OUT・他の AC は不変とする境界）、その境界に従った。全件性を主張する文言ではないため誤断定には当たらないが、訂正後の AC4（4件）と併読すると本文内に旧情報が残る形にはなる。IN 節・参考節にも4件目を追記するかは、Issue 本文の訂正範囲をどこまで広げるかの判断であり、レビュアーに委ねる。

## スコープ外（Issue の OUT / 別 Issue 相当）

- `scripts/lint-adr.sh` への `Related:` 退役参照検査の追加（J3=(A)。#474 系へ）
- `Amends:` / `Amended by:` の凍結参照（ADR-20260711-3 決定4）
- **`## Decision` 本文に残る退役 ADR への言及**（plan の前提確認 J5）。とくに `ADR-20260602-2:26` は `## Decision` 内から退役 `ADR-20260511` へ markdown リンクを張っており、`Related:` と同種の「生きた文書からの迂回」が Decision 節に残存する。ただし AC6（`## Decision` に差分がない）と正面衝突するため本 PR では触れていない。別 Issue が要る論点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
