### PR TITLE
feat(adr): drift-lint に有効ADRの Related 退役・dangling 検査（レイヤ4）を追加する（#522）

### DIFF
--- a/docs/adr/ADR-20260606-protection-priority-ladder.md
+++ b/docs/adr/ADR-20260606-protection-priority-ladder.md
@@ -62,7 +62,7 @@ validity: 有効
 
 ## 関連ADR
 
-- Related: ADR-20260602（principles を根拠ハブと位置づけ。本ADRの内容は principles.md 本体に置く方針の前提）
-- Related: ADR-20260602-2（自律度ラダーの二層構造＝本体ストック＋ADR採用決定。本ADRが倣った前例）
+- Related: ADR-20260602-principles-rationale-hub（principles を根拠ハブと位置づけ。本ADRの内容は principles.md 本体に置く方針の前提）
+- Related: ADR-20260602-2-autonomy-ladder-convention（自律度ラダーの二層構造＝本体ストック＋ADR採用決定。本ADRが倣った前例）
 - Related: ADR-20260606-2-instruction-tidying（本ADRの既存5決定は不変で、606-2 が6番目＝棚卸し（削除方向）の決定を追加。上書きでない）
 - 関連Issue: #228, #157

--- a/scripts/fixtures/lint-adr/invalid/18-related-retired-no-bullet/ADR-20261101-related-retired-nb-source.md
+++ b/scripts/fixtures/lint-adr/invalid/18-related-retired-no-bullet/ADR-20261101-related-retired-nb-source.md
@@ -1,0 +1,25 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261101-related-retired-nb-source: バレット無し Related が退役ADRを指す source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/18）。穴1（行頭バレット無し）の `Related:` 行が退役（廃止済み）ADR を指す。レイヤ4 が書式非依存に先頭 stem を抽出し退役参照違反を検出することを確認する。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 が参照先退役違反を報告し exit 1 になる。
+
+## 関連ADR
+
+Related: ADR-20261102-related-retired-nb-target（バレット無しの一方向 Related。参照先は廃止済みで退役参照検査を発火させる）

--- a/scripts/fixtures/lint-adr/invalid/18-related-retired-no-bullet/ADR-20261102-related-retired-nb-target.md
+++ b/scripts/fixtures/lint-adr/invalid/18-related-retired-no-bullet/ADR-20261102-related-retired-nb-target.md
@@ -1,0 +1,21 @@
+---
+status: 承認済み
+validity: 廃止済み
+---
+# ADR-20261102-related-retired-nb-target: 退役（廃止済み）の参照先
+
+## Status
+
+承認済み（廃止済み）
+
+## Context
+
+fixture 用（invalid/18）。source から Related される退役（廃止済み）ADR。superseded-by を持たないためレイヤ1合法・レイヤ3非対象で、退役参照違反のみを分離する。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+index には現れない（有効でないため）。

--- a/scripts/fixtures/lint-adr/invalid/18-related-retired-no-bullet/index.md
+++ b/scripts/fixtures/lint-adr/invalid/18-related-retired-no-bullet/index.md
@@ -1,0 +1,4 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261101-related-retired-nb-source](./ADR-20261101-related-retired-nb-source.md): バレット無し Related が退役ADRを指す source

--- a/scripts/fixtures/lint-adr/invalid/19-related-retired-link/ADR-20261111-related-retired-link-source.md
+++ b/scripts/fixtures/lint-adr/invalid/19-related-retired-link/ADR-20261111-related-retired-link-source.md
@@ -1,0 +1,25 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261111-related-retired-link-source: リンク形式 Related が退役ADRを指す source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/19）。穴2（markdown リンク形式）の `Related:` 行が退役（上書き済み）ADR を指す。レイヤ4 がリンク先頭の `[` を吸収して stem を抽出し退役参照違反を検出することを確認する。参照先の退役ペアはレイヤ3双方向を満たし、退役違反のみを分離する。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 が参照先退役違反を報告し exit 1 になる（相互参照違反は出ない）。
+
+## 関連ADR
+
+- Related: [ADR-20261112-related-retired-link-old](./ADR-20261112-related-retired-link-old.md)（リンク形式の一方向 Related。参照先は上書き済みで退役参照検査を発火させる）

--- a/scripts/fixtures/lint-adr/invalid/19-related-retired-link/ADR-20261112-related-retired-link-old.md
+++ b/scripts/fixtures/lint-adr/invalid/19-related-retired-link/ADR-20261112-related-retired-link-old.md
@@ -1,0 +1,26 @@
+---
+status: 承認済み
+validity: 上書き済み
+superseded-by: ADR-20261113-related-retired-link-new
+---
+# ADR-20261112-related-retired-link-old: 退役（上書き済み）の参照先（旧）
+
+## Status
+
+承認済み（上書き済み）
+
+## Context
+
+fixture 用（invalid/19）。source から Related される退役（上書き済み）ADR。後継 ADR-20261113 とレイヤ3双方向を満たす。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+index には現れない（有効でないため）。
+
+## 関連ADR
+
+- Superseded by: ADR-20261113-related-retired-link-new（レイヤ3双方向 fixture のペア）

--- a/scripts/fixtures/lint-adr/invalid/19-related-retired-link/ADR-20261113-related-retired-link-new.md
+++ b/scripts/fixtures/lint-adr/invalid/19-related-retired-link/ADR-20261113-related-retired-link-new.md
@@ -1,0 +1,25 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261113-related-retired-link-new: 後継（有効）
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/19）。ADR-20261112 を上書きした後継。レイヤ3双方向を満たすため本文で Supersedes を宣言する。本 ADR の Related は持たない（source は ADR-20261111 のみ）。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+fixture として index 生成器の入力に使う。
+
+## 関連ADR
+
+- Supersedes: ADR-20261112-related-retired-link-old（レイヤ3双方向 fixture のペア）

--- a/scripts/fixtures/lint-adr/invalid/19-related-retired-link/index.md
+++ b/scripts/fixtures/lint-adr/invalid/19-related-retired-link/index.md
@@ -1,0 +1,5 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261111-related-retired-link-source](./ADR-20261111-related-retired-link-source.md): リンク形式 Related が退役ADRを指す source
+- [ADR-20261113-related-retired-link-new](./ADR-20261113-related-retired-link-new.md): 後継（有効）

--- a/scripts/fixtures/lint-adr/invalid/20-related-dangling/ADR-20261201-related-dangling-source.md
+++ b/scripts/fixtures/lint-adr/invalid/20-related-dangling/ADR-20261201-related-dangling-source.md
@@ -1,0 +1,25 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261201-related-dangling-source: Related が非存在 slug を指す source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/20）。`Related:` の参照先ファイルが存在しない（dangling）。レイヤ4 が実在チェックで dangling 参照違反（AC8 の「解決不能な参照先」＝fail-safe をここに統合）を報告することを確認する。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 が dangling 参照違反を報告し exit 1 になる。
+
+## 関連ADR
+
+- Related: ADR-20261299-does-not-exist（存在しない参照先。dangling ＝ AC8 fail-safe を発火させる）

--- a/scripts/fixtures/lint-adr/invalid/20-related-dangling/index.md
+++ b/scripts/fixtures/lint-adr/invalid/20-related-dangling/index.md
@@ -1,0 +1,4 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261201-related-dangling-source](./ADR-20261201-related-dangling-source.md): Related が非存在 slug を指す source

--- a/scripts/fixtures/lint-adr/invalid/21-park-dangling/ADR-20261211-park-dangling-source.md
+++ b/scripts/fixtures/lint-adr/invalid/21-park-dangling/ADR-20261211-park-dangling-source.md
@@ -10,7 +10,7 @@ validity: 有効
 
 ## Context
 
-fixture 用（invalid/21）。`## 保留した決定`（パーク欄）の参照先ファイルが存在しない（dangling）。レイヤ4 が park 欄も dangling 検査の対象に含めることを確認する（退役検査は park には非適用＝J4）。
+fixture 用（invalid/21）。`## 保留した決定`（パーク欄）の参照先ファイルが存在しない（dangling）。レイヤ4 が park 欄も dangling 検査の対象に含めることを確認する（退役検査は park には非適用＝J4）。参照は markdown リンク形式で書き、同一 stem がラベル部とパス部に2回現れても違反が二重報告されない（dedup）ことも確認する。
 
 ## Decision
 
@@ -22,4 +22,4 @@ fixture 用のため実質的な決定内容は無い。
 
 ## 保留した決定
 
-- あるfacet を未決のまま残す（想定継承先: ADR-20261298-park-missing）
+- あるfacet を未決のまま残す（想定継承先: [ADR-20261298-park-missing](./ADR-20261298-park-missing.md)）

--- a/scripts/fixtures/lint-adr/invalid/21-park-dangling/ADR-20261211-park-dangling-source.md
+++ b/scripts/fixtures/lint-adr/invalid/21-park-dangling/ADR-20261211-park-dangling-source.md
@@ -1,0 +1,25 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261211-park-dangling-source: 保留した決定が非存在 slug を指す source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/21）。`## 保留した決定`（パーク欄）の参照先ファイルが存在しない（dangling）。レイヤ4 が park 欄も dangling 検査の対象に含めることを確認する（退役検査は park には非適用＝J4）。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 が dangling 参照違反を報告し exit 1 になる。
+
+## 保留した決定
+
+- あるfacet を未決のまま残す（想定継承先: ADR-20261298-park-missing）

--- a/scripts/fixtures/lint-adr/invalid/21-park-dangling/index.md
+++ b/scripts/fixtures/lint-adr/invalid/21-park-dangling/index.md
@@ -1,0 +1,4 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261211-park-dangling-source](./ADR-20261211-park-dangling-source.md): 保留した決定が非存在 slug を指す source

--- a/scripts/fixtures/lint-adr/invalid/22-related-link-label/ADR-20261301-related-linklabel-source.md
+++ b/scripts/fixtures/lint-adr/invalid/22-related-link-label/ADR-20261301-related-linklabel-source.md
@@ -1,0 +1,25 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261301-related-linklabel-source: リンクラベルが説明文の Related が退役ADRを指す source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/22）。`Related:` のリンクラベルが説明文で ADR stem がパス部にのみ現れる書式（`[詳細はこちら](./ADR-X.md)`）でも、`Related:` 以降で最初に現れる ADR stem を抽出して退役参照違反を検出することを確認する（書式非依存の適用範囲＝リンクラベル書式。PR #545 セルフレビュー反映）。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 が参照先退役違反を報告し exit 1 になる。
+
+## 関連ADR
+
+- Related: [詳細はこちら](./ADR-20261302-related-linklabel-target.md)（リンクラベルが説明文で stem はパス部のみ。書式非依存で退役参照検査を発火させる）

--- a/scripts/fixtures/lint-adr/invalid/22-related-link-label/ADR-20261302-related-linklabel-target.md
+++ b/scripts/fixtures/lint-adr/invalid/22-related-link-label/ADR-20261302-related-linklabel-target.md
@@ -1,0 +1,21 @@
+---
+status: 承認済み
+validity: 廃止済み
+---
+# ADR-20261302-related-linklabel-target: 退役（廃止済み）の参照先（リンクラベル書式）
+
+## Status
+
+承認済み（廃止済み）
+
+## Context
+
+fixture 用（invalid/22）。source からリンクラベルが説明文の Related で参照される退役（廃止済み）ADR。superseded-by を持たないためレイヤ1合法・レイヤ3非対象。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+index には現れない（有効でないため）。

--- a/scripts/fixtures/lint-adr/invalid/22-related-link-label/index.md
+++ b/scripts/fixtures/lint-adr/invalid/22-related-link-label/index.md
@@ -1,0 +1,4 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261301-related-linklabel-source](./ADR-20261301-related-linklabel-source.md): リンクラベルが説明文の Related が退役ADRを指す source

--- a/scripts/fixtures/lint-adr/invalid/23-related-dup-report/ADR-20261401-related-dup-source.md
+++ b/scripts/fixtures/lint-adr/invalid/23-related-dup-report/ADR-20261401-related-dup-source.md
@@ -1,0 +1,26 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261401-related-dup-source: 同一退役ADRを複数Related行から参照する source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（invalid/23）。同一の退役（廃止済み）ADR を、書式の異なる2本の `Related:` 行（plain＋markdown リンク）から参照する。extract_body_related のファイル内 dedup により参照先退役違反が**1回のみ**報告される（park 側 dedup と対称）ことを固定する回帰。dedup を外すと二重報告に戻る。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 が参照先退役違反を1回のみ報告し exit 1 になる。
+
+## 関連ADR
+
+- Related: ADR-20261402-related-dup-target（同一退役先への1本目・plain 書式）
+- Related: [ADR-20261402-related-dup-target](./ADR-20261402-related-dup-target.md)（同一退役先への2本目・リンク書式。dedup 検証）

--- a/scripts/fixtures/lint-adr/invalid/23-related-dup-report/ADR-20261402-related-dup-target.md
+++ b/scripts/fixtures/lint-adr/invalid/23-related-dup-report/ADR-20261402-related-dup-target.md
@@ -1,0 +1,21 @@
+---
+status: 承認済み
+validity: 廃止済み
+---
+# ADR-20261402-related-dup-target: 退役（廃止済み）の参照先（dedup 検証用）
+
+## Status
+
+承認済み（廃止済み）
+
+## Context
+
+fixture 用（invalid/23）。source が複数の `Related:` 行から重複して指す退役（廃止済み）ADR。superseded-by を持たないためレイヤ1合法・レイヤ3非対象。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+index には現れない（有効でないため）。

--- a/scripts/fixtures/lint-adr/invalid/23-related-dup-report/index.md
+++ b/scripts/fixtures/lint-adr/invalid/23-related-dup-report/index.md
@@ -1,0 +1,4 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261401-related-dup-source](./ADR-20261401-related-dup-source.md): 同一退役ADRを複数Related行から参照する source

--- a/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261231-related-valid-source.md
+++ b/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261231-related-valid-source.md
@@ -1,0 +1,34 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261231-related-valid-source: 全書式の Related が有効先を指す source
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（valid/06）。バレット有無×リンク有無の4書式の `Related:` がいずれも有効 ADR を先頭 stem に持つ。散文が退役 slug を引用しても先頭 stem が有効なら誤検出しないこと、`## 保留した決定`（パーク欄）が有効先・退役先(存在)のいずれを指しても違反にならないこと（J4＝park は dangling 検査のみ）を確認する。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+レイヤ4 は退役・dangling とも誤検出せず exit 0 を維持する。
+
+## 保留した決定
+
+- あるfacet を未決のまま残す（想定継承先: ADR-20261232-related-valid-target-a）
+- 別facet を未決のまま残す（想定継承先: ADR-20261234-related-valid-retired-mentioned）（park は dangling 検査のみ＝退役でも違反にしない）
+
+## 関連ADR
+
+- Related: ADR-20261232-related-valid-target-a（バレット＋plain、有効先）
+Related: ADR-20261233-related-valid-target-b（穴1 バレット無し＋plain、有効先）
+- Related: [ADR-20261232-related-valid-target-a](./ADR-20261232-related-valid-target-a.md)（穴2 バレット＋リンク、有効先）
+Related: [ADR-20261233-related-valid-target-b](./ADR-20261233-related-valid-target-b.md)（穴1＋穴2 バレット無し＋リンク、有効先）
+- Related: ADR-20261233-related-valid-target-b（先頭stem＝有効。分割以前は上書き済みの ADR-20261234-related-valid-retired-mentioned を指していた＝散文の退役引用は先頭stemでないため誤検出しない）

--- a/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261232-related-valid-target-a.md
+++ b/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261232-related-valid-target-a.md
@@ -1,0 +1,21 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261232-related-valid-target-a: 有効な参照先 A
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（valid/06）。source から Related／park される有効な参照先。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+fixture として index 生成器の入力に使う。

--- a/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261233-related-valid-target-b.md
+++ b/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261233-related-valid-target-b.md
@@ -1,0 +1,21 @@
+---
+status: 承認済み
+validity: 有効
+---
+# ADR-20261233-related-valid-target-b: 有効な参照先 B
+
+## Status
+
+承認済み
+
+## Context
+
+fixture 用（valid/06）。source から Related される有効な参照先（バレット無し・リンク形式の検証に使う）。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+fixture として index 生成器の入力に使う。

--- a/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261234-related-valid-retired-mentioned.md
+++ b/scripts/fixtures/lint-adr/valid/06-related-valid/ADR-20261234-related-valid-retired-mentioned.md
@@ -1,0 +1,21 @@
+---
+status: 承認済み
+validity: 廃止済み
+---
+# ADR-20261234-related-valid-retired-mentioned: 散文・park で言及される退役（廃止済み）ADR
+
+## Status
+
+承認済み（廃止済み）
+
+## Context
+
+fixture 用（valid/06）。source の `Related:` 説明散文で引用され（先頭 stem ではない）、かつ park 欄からも指される退役（廃止済み・実在）ADR。散文引用は退役検査に掛からず、park からの参照は dangling 検査のみ（J4）で退役でも違反にならないことを確認する。
+
+## Decision
+
+fixture 用のため実質的な決定内容は無い。
+
+## Consequences
+
+index には現れない（有効でないため）。実在するため dangling ではない。

--- a/scripts/fixtures/lint-adr/valid/06-related-valid/index.md
+++ b/scripts/fixtures/lint-adr/valid/06-related-valid/index.md
@@ -1,0 +1,6 @@
+<!-- このファイルは scripts/gen-adr-index.sh による生成物。手動編集禁止。 -->
+# 有効 ADR インデックス
+
+- [ADR-20261231-related-valid-source](./ADR-20261231-related-valid-source.md): 全書式の Related が有効先を指す source
+- [ADR-20261232-related-valid-target-a](./ADR-20261232-related-valid-target-a.md): 有効な参照先 A
+- [ADR-20261233-related-valid-target-b](./ADR-20261233-related-valid-target-b.md): 有効な参照先 B

--- a/scripts/lint-adr.sh
+++ b/scripts/lint-adr.sh
@@ -69,10 +69,12 @@
 # 関係の参照妥当性 lint）＋ Issue #522。有効 ADR（validity=有効）の本文
 # `## 関連ADR` の `Related:` 行、および `## 保留した決定`（パーク欄）が指す ADR
 # 参照先について、参照先の生存性（退役）・実在性（dangling）を検証する。
-#   - 判定単位（書式非依存）: `Related:` 以降の最初の ADR stem を、行頭バレット
-#     （`-`）の有無・markdown リンク（`[stem](...)`）の有無を問わず抽出する
-#     （Issue #522 穴1・穴2）。判定単位はどの ADR にも成文化されておらず、本実装＋
-#     fixture（scripts/fixtures/lint-adr/）を正とする。#491 決定2 の遡及改稿はしない。
+#   - 判定単位（書式非依存）: `Related:` 以降で最初に現れる ADR stem を抽出する。行頭
+#     バレット（`-`）の有無・markdown リンク（`[stem](...)`）の有無・リンクラベルが stem
+#     か説明文か（`- Related: [詳細](./ADR-X.md)` も ADR-X を取る）を問わない
+#     （Issue #522 穴1・穴2＋リンクラベル書式）。説明散文中の後続 stem は先頭優先で拾わない
+#     （誤検出回避）。判定単位はどの ADR にも成文化されておらず、本実装＋fixture
+#     （scripts/fixtures/lint-adr/）を正とする。#491 決定2 の遡及改稿はしない。
 #   - 参照先退役違反: `Related:` 参照先が実在し、かつ validity が 上書き済み／
 #     廃止済み（RETIRED_VALIDITY）なら違反（有効 ADR が退役 ADR を指す参照を残さない）。
 #   - dangling 参照違反: `Related:`／パーク欄の参照先 `<slug>.md` が実在しなければ
@@ -89,6 +91,11 @@
 #     Issue 番号参照（`#<番号>`）は検査しない（§3 の不検査）。
 #   - パーク欄の参照先抽出は節内の ADR トークンを全抽出する（J3）。将来パーク欄の
 #     説明散文が退役/不在 ADR を引用すると誤検出しうる点に注意。
+#   - 既知の限界（意図的）: (a) 1つの `Related:` 行に複数 ADR を列挙した場合は先頭 stem
+#     のみ検査する（#491 決定2 の判定単位＝先頭 stem を継承。2件目以降は対象外）。
+#     (b) 参照先が旧形式（front-matter 無し）・validity 空（提案中/却下）の場合は退役でも
+#     dangling でもないとして違反にしない（fail-open。RETIRED_VALIDITY＝上書き済み/廃止済み
+#     の完全一致のみを退役とみなす）。旧形式ADRはレイヤ1でも検査対象外である点と整合する。
 #
 # 全違反を列挙してから最後に非0 exitする（早期returnで打ち切らない）。
 #
@@ -265,8 +272,7 @@ extract_body_supersedes() {
 # （誤検出回避の要）。
 extract_body_related() {
     local file="$1"
-    local line in_section=0
-    local re='^[[:space:]]*(-[[:space:]]*)?Related:[[:space:]]*\[?(ADR-[A-Za-z0-9-]+)'
+    local line in_section=0 after stem existing dup
 
     BODY_RELATED_TARGETS=()
 
@@ -279,8 +285,28 @@ extract_body_related() {
             in_section=0
             continue
         fi
-        if [ "$in_section" -eq 1 ] && [[ "$line" =~ $re ]]; then
-            BODY_RELATED_TARGETS+=("${BASH_REMATCH[2]}")
+        # `Related:` 行（行頭バレット任意）から「`Related:` 以降で最初に現れる ADR stem」を
+        # 1件抽出する。`${line#*Related:}` で `Related:` 以降へ絞り、そこから最左の
+        # `ADR-<stem>` を取ることで、バレット有無・リンク有無・リンクラベルが stem か
+        # 説明文か（`[詳細](./ADR-X.md)`）を問わず先頭 stem を得る。説明散文中の後続 stem は
+        # 先頭優先で拾わない（誤検出回避）。
+        if [ "$in_section" -eq 1 ] && [[ "$line" =~ ^[[:space:]]*(-[[:space:]]*)?Related: ]]; then
+            after="${line#*Related:}"
+            if [[ "$after" =~ (ADR-[A-Za-z0-9-]+) ]]; then
+                stem="${BASH_REMATCH[1]}"
+                # 同一 stem の重複登録を避ける（複数 `Related:` 行が同じ退役/非存在 ADR を
+                # 指す場合の二重報告を防ぐ。extract_park_adr_refs の dedup と対称）。
+                dup=0
+                for existing in ${BODY_RELATED_TARGETS[@]+"${BODY_RELATED_TARGETS[@]}"}; do
+                    if [ "$existing" = "$stem" ]; then
+                        dup=1
+                        break
+                    fi
+                done
+                if [ "$dup" -eq 0 ]; then
+                    BODY_RELATED_TARGETS+=("$stem")
+                fi
+            fi
         fi
     done <"$file"
 }

--- a/scripts/lint-adr.sh
+++ b/scripts/lint-adr.sh
@@ -65,6 +65,27 @@
 # `Supersedes:` 行は行頭空白（入れ子/インデントされたバレット）を許容して
 # 抽出する（forward の照合・reverse の抽出のいずれも同一の緩和を適用）。
 #
+# レイヤ4（Related/park 参照の生存性・実在性）: ADR-20260720-4 §3（非 Supersede
+# 関係の参照妥当性 lint）＋ Issue #522。有効 ADR（validity=有効）の本文
+# `## 関連ADR` の `Related:` 行、および `## 保留した決定`（パーク欄）が指す ADR
+# 参照先について、参照先の生存性（退役）・実在性（dangling）を検証する。
+#   - 判定単位（書式非依存）: `Related:` 以降の最初の ADR stem を、行頭バレット
+#     （`-`）の有無・markdown リンク（`[stem](...)`）の有無を問わず抽出する
+#     （Issue #522 穴1・穴2）。判定単位はどの ADR にも成文化されておらず、本実装＋
+#     fixture（scripts/fixtures/lint-adr/）を正とする。#491 決定2 の遡及改稿はしない。
+#   - 参照先退役違反: `Related:` 参照先が実在し、かつ validity が 上書き済み／
+#     廃止済み（RETIRED_VALIDITY）なら違反（有効 ADR が退役 ADR を指す参照を残さない）。
+#   - dangling 参照違反: `Related:`／パーク欄の参照先 `<slug>.md` が実在しなければ
+#     違反（full slug 完全一致で解決。解決不能な参照先＝AC8 fail-safe をここに統合）。
+#   - パーク欄は dangling 検査のみ（退役検査は非適用）。パーク欄は凍結スナップショット
+#     で後から編集不能なため、参照先が後に退役しても修復不能な違反を作らない
+#     （§3 が `Related:` 双方向を強制しない論理と同型。Issue #522 J4）。
+#   - source は有効 ADR のみ（退役・提案中・却下・旧形式は走査対象外）。双方向性は
+#     強制しない（一方向 `Related:` は合法。§3）。パークの open/resolved 状態・
+#     Issue 番号参照（`#<番号>`）は検査しない（§3 の不検査）。
+#   - パーク欄の参照先抽出は節内の ADR トークンを全抽出する（J3）。将来パーク欄の
+#     説明散文が退役/不在 ADR を引用すると誤検出しうる点に注意。
+#
 # 全違反を列挙してから最後に非0 exitする（早期returnで打ち切らない）。
 #
 # 使い方:
@@ -88,6 +109,9 @@ fi
 # 正本の語彙が変わったときの追随点を1箇所に集約する。
 STATUS_VOCAB=("提案中" "承認済み" "却下")
 VALIDITY_VOCAB=("有効" "上書き済み" "廃止済み")
+# レイヤ4（Issue #522）で「退役」とみなす validity 値（VALIDITY_VOCAB の部分集合）。
+# 正本語彙が変わった際の追随点を1箇所へ集約する。
+RETIRED_VALIDITY=("上書き済み" "廃止済み")
 
 # 値 $1 が第2引数以降の語彙集合に含まれるかを判定する。
 # 戻り値: 含まれれば 0、含まれなければ 1
@@ -229,6 +253,63 @@ extract_body_supersedes() {
     done <"$file"
 }
 
+# ファイル file の本文 `## 関連ADR` 節（次の `## ` 見出しまたはファイル末尾まで）の
+# 各 `Related:` 行について、行頭バレット（`-`）有無・markdown リンク（`[stem](...)`）
+# 有無を問わず「`Related:` 以降の最初の ADR stem」を1件抽出し、グローバル配列
+# BODY_RELATED_TARGETS へ格納する（0件なら空配列）。レイヤ4 の照合対象を集める。
+# 先頭 stem のみを取るため、説明散文中の後続 ADR stem（退役を含む）は抽出しない
+# （誤検出回避の要）。
+extract_body_related() {
+    local file="$1"
+    local line in_section=0
+    local re='^[[:space:]]*(-[[:space:]]*)?Related:[[:space:]]*\[?(ADR-[A-Za-z0-9-]+)'
+
+    BODY_RELATED_TARGETS=()
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [[ "$line" =~ ^##[[:space:]]+関連ADR ]]; then
+            in_section=1
+            continue
+        fi
+        if [ "$in_section" -eq 1 ] && [[ "$line" =~ ^##[[:space:]] ]]; then
+            in_section=0
+            continue
+        fi
+        if [ "$in_section" -eq 1 ] && [[ "$line" =~ $re ]]; then
+            BODY_RELATED_TARGETS+=("${BASH_REMATCH[2]}")
+        fi
+    done <"$file"
+}
+
+# ファイル file の本文 `## 保留した決定` 節（次の `## ` 見出しまたはファイル末尾まで）に
+# ある ADR stem（`ADR-<...>`）を全て抽出し、グローバル配列 PARK_ADR_TARGETS へ格納する
+# （0件なら空配列）。ADR-20260720-4 §3「パーク欄が ADR を指す <slug>」の字義に従い節内の
+# ADR トークンを全抽出する（Issue #522 J3）。Issue 番号参照（`#<番号>`）は対象外。
+extract_park_adr_refs() {
+    local file="$1"
+    local line in_section=0 rest
+
+    PARK_ADR_TARGETS=()
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [[ "$line" =~ ^##[[:space:]]+保留した決定 ]]; then
+            in_section=1
+            continue
+        fi
+        if [ "$in_section" -eq 1 ] && [[ "$line" =~ ^##[[:space:]] ]]; then
+            in_section=0
+            continue
+        fi
+        if [ "$in_section" -eq 1 ]; then
+            rest="$line"
+            while [[ "$rest" =~ (ADR-[A-Za-z0-9-]+) ]]; do
+                PARK_ADR_TARGETS+=("${BASH_REMATCH[1]}")
+                rest="${rest#*"${BASH_REMATCH[1]}"}"
+            done
+        fi
+    done <"$file"
+}
+
 # ファイル名昇順で走査対象を収集
 files=()
 shopt -s nullglob
@@ -255,6 +336,10 @@ xref_targets=()
 #   参照時は "${FM_SB_BY_STEM[$stem]:-}" で空扱いにする）
 declare -A FM_SB_BY_STEM=()
 
+# レイヤ4 の照合用: stem -> front-matter validity 値（front-matter を持つ ADR のみ。
+# 持たない旧形式はキー未設定＝参照時 "${FM_VALIDITY_BY_STEM[$stem]:-}" で空扱いにする）
+declare -A FM_VALIDITY_BY_STEM=()
+
 for file in "${sorted[@]}"; do
     if ! extract_frontmatter "$file"; then
         # front-matter を持たない旧形式はレイヤ1検査対象外（スキップ）
@@ -262,6 +347,7 @@ for file in "${sorted[@]}"; do
     fi
 
     FM_SB_BY_STEM["$(basename "$file" .md)"]="$FM_SUPERSEDED_BY"
+    FM_VALIDITY_BY_STEM["$(basename "$file" .md)"]="$FM_VALIDITY"
 
     # 種別1・4: status の存在と語彙
     # 空のときは種別1のみを報告する（語彙違反として二重に数えない）
@@ -399,6 +485,37 @@ for c_file in "${sorted[@]}"; do
         done
         if [ "$member" -eq 0 ]; then
             printf '%s: 相互参照違反（逆方向: %s の本文 "## 関連ADR" が "Supersedes: %s" を宣言していますが、%s の front-matter superseded-by がそれを指していません）\n' "$t_file" "$c_file" "$t_stem" "$t_file"
+            violations=$((violations + 1))
+        fi
+    done
+done
+
+# レイヤ4: 有効ADRの Related/park 参照の退役・dangling 検査
+# （Issue #522, ADR-20260720-4 §3。判定単位は書式非依存の先頭 stem 抽出）
+for src_file in "${sorted[@]}"; do
+    src_stem="$(basename "$src_file" .md)"
+    # source は有効 ADR のみ（退役・提案中・却下・旧形式は検査対象外）
+    if [ "${FM_VALIDITY_BY_STEM[$src_stem]:-}" != "有効" ]; then
+        continue
+    fi
+
+    # `## 関連ADR` の Related 参照先: 非存在→dangling、実在かつ退役→参照先退役違反
+    extract_body_related "$src_file"
+    for t_stem in ${BODY_RELATED_TARGETS[@]+"${BODY_RELATED_TARGETS[@]}"}; do
+        if [ ! -f "$ADR_DIR/$t_stem.md" ]; then
+            printf '%s: dangling 参照違反（"## 関連ADR" の Related 参照先 %s が見つかりません）\n' "$src_file" "$t_stem"
+            violations=$((violations + 1))
+        elif in_vocab "${FM_VALIDITY_BY_STEM[$t_stem]:-}" "${RETIRED_VALIDITY[@]}"; then
+            printf '%s: 参照先退役違反（"## 関連ADR" の Related 参照先 %s は validity=%s の退役ADRです）\n' "$src_file" "$t_stem" "${FM_VALIDITY_BY_STEM[$t_stem]:-}"
+            violations=$((violations + 1))
+        fi
+    done
+
+    # `## 保留した決定`（park）参照先: dangling 検査のみ（退役検査は非適用＝J4）
+    extract_park_adr_refs "$src_file"
+    for p_stem in ${PARK_ADR_TARGETS[@]+"${PARK_ADR_TARGETS[@]}"}; do
+        if [ ! -f "$ADR_DIR/$p_stem.md" ]; then
+            printf '%s: dangling 参照違反（"## 保留した決定" の参照先 %s が見つかりません）\n' "$src_file" "$p_stem"
             violations=$((violations + 1))
         fi
     done

--- a/scripts/lint-adr.sh
+++ b/scripts/lint-adr.sh
@@ -80,8 +80,12 @@
 #   - パーク欄は dangling 検査のみ（退役検査は非適用）。パーク欄は凍結スナップショット
 #     で後から編集不能なため、参照先が後に退役しても修復不能な違反を作らない
 #     （§3 が `Related:` 双方向を強制しない論理と同型。Issue #522 J4）。
-#   - source は有効 ADR のみ（退役・提案中・却下・旧形式は走査対象外）。双方向性は
-#     強制しない（一方向 `Related:` は合法。§3）。パークの open/resolved 状態・
+#   - source は有効 ADR のみに限定する。ADR-20260720-4 §3 は検査対象を「front-matter
+#     を持つ ADR」と広く書くが、退役（凍結）ADR は編集不能で dangling/退役参照を修復
+#     できず修復不能な違反を課すことになる（パーク欄を退役検査から外すのと同じ理由。
+#     Issue #522 J4）。提案中・却下 ADR の参照はまだ確定した決定の一部でないため対象外と
+#     する。結果として検査対象は Issue #522 タイトル「有効ADRの…」に一致する。
+#   - 双方向性は強制しない（一方向 `Related:` は合法。§3）。パークの open/resolved 状態・
 #     Issue 番号参照（`#<番号>`）は検査しない（§3 の不検査）。
 #   - パーク欄の参照先抽出は節内の ADR トークンを全抽出する（J3）。将来パーク欄の
 #     説明散文が退役/不在 ADR を引用すると誤検出しうる点に注意。
@@ -287,7 +291,7 @@ extract_body_related() {
 # ADR トークンを全抽出する（Issue #522 J3）。Issue 番号参照（`#<番号>`）は対象外。
 extract_park_adr_refs() {
     local file="$1"
-    local line in_section=0 rest
+    local line in_section=0 rest stem existing dup
 
     PARK_ADR_TARGETS=()
 
@@ -303,8 +307,21 @@ extract_park_adr_refs() {
         if [ "$in_section" -eq 1 ]; then
             rest="$line"
             while [[ "$rest" =~ (ADR-[A-Za-z0-9-]+) ]]; do
-                PARK_ADR_TARGETS+=("${BASH_REMATCH[1]}")
-                rest="${rest#*"${BASH_REMATCH[1]}"}"
+                stem="${BASH_REMATCH[1]}"
+                rest="${rest#*"$stem"}"
+                # 同一 stem の重複登録を避ける。markdown リンク形式 `[stem](./stem.md)` は
+                # 1参照でラベル部とパス部に同一 stem が2回現れるため、dedup しないと違反を
+                # 二重報告する。抽出は最長トークン（`+` 貪欲）ゆえ prefix 衝突は起きない。
+                dup=0
+                for existing in ${PARK_ADR_TARGETS[@]+"${PARK_ADR_TARGETS[@]}"}; do
+                    if [ "$existing" = "$stem" ]; then
+                        dup=1
+                        break
+                    fi
+                done
+                if [ "$dup" -eq 0 ]; then
+                    PARK_ADR_TARGETS+=("$stem")
+                fi
             done
         fi
     done <"$file"

--- a/scripts/test-lint-adr.sh
+++ b/scripts/test-lint-adr.sh
@@ -730,6 +730,101 @@ run_ac5_edit_mechanism() {
 
 run_ac5_edit_mechanism
 
+# ==== #522: レイヤ4（有効ADRの Related/park 参照の退役・dangling 検査） ====
+# 出典 ADR-20260720-4 §3（非 Supersede 参照妥当性 lint）＋ Issue #522（退役参照検査・
+# 判定単位の書式非依存化）。有効 ADR の `## 関連ADR`（Related:）／`## 保留した決定`（park）
+# の先頭 ADR stem を、行頭バレット有無・markdown リンク形式有無を問わず抽出し、参照先が
+# 退役（上書き済み/廃止済み）なら参照先退役違反、非存在なら dangling 参照違反として報告する。
+# park は dangling のみ（退役非適用＝J4）。ラベルは #522 併記で既存 run_ac5_edit_mechanism
+# （#515 の別 AC5）との混同を避ける。
+
+# AC1/AC2(穴1): バレット無し＋plain の Related が廃止済みADRを指す → 参照先退役違反
+run_xref_list_case \
+    "$FIXTURES_DIR/invalid/18-related-retired-no-bullet" 1 \
+    "#522(AC1/AC2-穴1): バレット無し Related が退役ADRを指すと参照先退役違反" \
+    "contains:参照先退役違反" \
+    "contains:ADR-20261102-related-retired-nb-target"
+
+# AC1/AC2(穴2): リンク形式の Related が上書き済みADRを指す → 参照先退役違反（相互参照違反は出ない）
+run_xref_list_case \
+    "$FIXTURES_DIR/invalid/19-related-retired-link" 1 \
+    "#522(AC1/AC2-穴2): リンク形式 Related が退役ADRを指すと参照先退役違反" \
+    "contains:参照先退役違反" \
+    "contains:ADR-20261112-related-retired-link-old" \
+    "notcontains:相互参照違反"
+
+# AC6/AC8: Related が非存在 slug を指す → dangling 参照違反（解決不能＝fail-safe を統合）
+run_xref_list_case \
+    "$FIXTURES_DIR/invalid/20-related-dangling" 1 \
+    "#522(AC6/AC8): Related が非存在slugを指すと dangling 参照違反" \
+    "contains:dangling 参照違反" \
+    "contains:ADR-20261299-does-not-exist"
+
+# AC6/AC7: park 欄が非存在 slug を指す → dangling 参照違反（park も dangling 検査の対象）
+run_xref_list_case \
+    "$FIXTURES_DIR/invalid/21-park-dangling" 1 \
+    "#522(AC6/AC7): 保留した決定が非存在slugを指すと dangling 参照違反" \
+    "contains:dangling 参照違反" \
+    "contains:ADR-20261298-park-missing"
+
+# AC2/AC7(誤検出回避): 全4書式の有効参照・散文の退役引用・park→有効/退役(存在)は
+# いずれも違反にならず exit 0（先頭stem抽出の要、park は dangling のみ＝J4 の正方向固定）
+run_xref_list_case \
+    "$FIXTURES_DIR/valid/06-related-valid" 0 \
+    "#522(AC2/AC7-誤検出回避): 全書式の有効参照・散文退役引用・park退役(存在)は exit 0" \
+    "notcontains:参照先退役違反" \
+    "notcontains:dangling 参照違反"
+
+# AC4/AC9: レイヤ4追加後も実 docs/adr が exit 0（退役・dangling ゼロ）。追加検査が既存の
+# 有効参照を誤検出しないこと、および検査有効化前提として現行 corpus がクリーンであること
+# （Task 1 の短縮参照 full slug 展開を含む）の恒久ガード。
+run_real_corpus_clean() {
+    local corpus="$REPO_ROOT/docs/adr"
+
+    if [ ! -f "$LINT_ADR" ]; then
+        total=$((total + 1))
+        failed=$((failed + 1))
+        printf '[FAIL] #522(AC4/AC9): lint-adr.sh not found: %s\n' "$LINT_ADR"
+        return
+    fi
+
+    local output rc
+    set +e
+    output=$(bash "$LINT_ADR" "$corpus" 2>&1)
+    rc=$?
+    set -e
+
+    total=$((total + 1))
+    if [ "$rc" -eq 0 ]; then
+        printf '[PASS] #522(AC4/AC9): 実 docs/adr はレイヤ4追加後も exit 0\n'
+        passed=$((passed + 1))
+    else
+        printf '[FAIL] #522(AC4/AC9): 実 docs/adr は exit 0 を期待したが %d\n  output:\n%s\n' "$rc" "$output"
+        failed=$((failed + 1))
+    fi
+}
+
+run_real_corpus_clean
+
+# AC5: レイヤ4仕様のヘッダ成文化。判定単位の書式非依存化・退役/dangling 検査の仕様を
+# lint-adr.sh ヘッダに既存レイヤ1〜3 と同形式（決定を ADR 参照で明示）で成文化する。
+# 決定出典は ADR-20260720-4 §3。削除で red 化する必須アサート（run_ac5_edit_mechanism に倣う）。
+run_layer4_header_spec() {
+    if [ ! -f "$LINT_ADR" ]; then
+        total=$((total + 1))
+        failed=$((failed + 1))
+        printf '[FAIL] #522(AC5): lint-adr.sh not found: %s\n' "$LINT_ADR"
+        return
+    fi
+
+    local content
+    content=$(cat "$LINT_ADR")
+    assert_contains "$content" "レイヤ4" "#522(AC5): ヘッダにレイヤ4の記述が存在する"
+    assert_contains "$content" "ADR-20260720-4" "#522(AC5): ヘッダにレイヤ4の決定出典 ADR-20260720-4 が明記されている"
+}
+
+run_layer4_header_spec
+
 echo
 if [ "$failed" -eq 0 ]; then
     printf 'All tests passed: %d/%d\n' "$passed" "$total"

--- a/scripts/test-lint-adr.sh
+++ b/scripts/test-lint-adr.sh
@@ -753,6 +753,15 @@ run_xref_list_case \
     "contains:ADR-20261112-related-retired-link-old" \
     "notcontains:相互参照違反"
 
+# gap1(セルフレビュー反映): リンクラベルが説明文で stem がパス部のみの Related
+# （`- Related: [詳細](./ADR-X.md)`）でも先頭 stem 抽出で退役を検出する（書式非依存の
+# 適用範囲＝リンクラベル書式。旧実装は `Related:` 直後の stem 隣接を前提とし取り漏らした）
+run_xref_list_case \
+    "$FIXTURES_DIR/invalid/22-related-link-label" 1 \
+    "#522(gap1-リンクラベル書式): リンクラベルが説明文でも先頭stem抽出で退役検出" \
+    "contains:参照先退役違反" \
+    "contains:ADR-20261302-related-linklabel-target"
+
 # AC6/AC8: Related が非存在 slug を指す → dangling 参照違反（解決不能＝fail-safe を統合）
 run_xref_list_case \
     "$FIXTURES_DIR/invalid/20-related-dangling" 1 \

--- a/scripts/test-lint-adr.sh
+++ b/scripts/test-lint-adr.sh
@@ -818,6 +818,37 @@ run_layer4_park_link_dedup() {
 
 run_layer4_park_link_dedup
 
+# #522(related dup dedup): 同一 source が複数の `Related:` 行から同じ退役 ADR を指しても
+# 参照先退役違反は1回のみ報告する（extract_body_related のファイル内 dedup。park 側
+# run_layer4_park_link_dedup と対称の保護。dedup を外すと二重報告に戻る）。
+run_layer4_related_dup_dedup() {
+    local corpus="$FIXTURES_DIR/invalid/23-related-dup-report"
+
+    if [ ! -d "$corpus" ]; then
+        total=$((total + 1))
+        failed=$((failed + 1))
+        printf '[FAIL] #522(related dup dedup): missing fixture corpus: %s\n' "$corpus"
+        return
+    fi
+
+    local output count
+    set +e
+    output=$(bash "$LINT_ADR" "$corpus" 2>&1)
+    count=$(printf '%s\n' "$output" | grep -c "ADR-20261402-related-dup-target")
+    set -e
+
+    total=$((total + 1))
+    if [ "$count" -eq 1 ]; then
+        printf '[PASS] #522(related dup dedup): 複数Related行が同一退役ADRを指しても違反は1回のみ（count=%d）\n' "$count"
+        passed=$((passed + 1))
+    else
+        printf '[FAIL] #522(related dup dedup): 1回報告を期待したが %d 回\n  output:\n%s\n' "$count" "$output"
+        failed=$((failed + 1))
+    fi
+}
+
+run_layer4_related_dup_dedup
+
 run_real_corpus_clean() {
     local corpus="$REPO_ROOT/docs/adr"
 

--- a/scripts/test-lint-adr.sh
+++ b/scripts/test-lint-adr.sh
@@ -778,6 +778,37 @@ run_xref_list_case \
 # AC4/AC9: レイヤ4追加後も実 docs/adr が exit 0（退役・dangling ゼロ）。追加検査が既存の
 # 有効参照を誤検出しないこと、および検査有効化前提として現行 corpus がクリーンであること
 # （Task 1 の短縮参照 full slug 展開を含む）の恒久ガード。
+# #522(park link dedup): park 参照が markdown リンク形式（`[stem](./stem.md)`）でも
+# dangling 違反は1回のみ報告する（ラベル部とパス部で同一 stem を二重報告しない回帰。
+# invalid/21 の park 参照はリンク形式）。
+run_layer4_park_link_dedup() {
+    local corpus="$FIXTURES_DIR/invalid/21-park-dangling"
+
+    if [ ! -d "$corpus" ]; then
+        total=$((total + 1))
+        failed=$((failed + 1))
+        printf '[FAIL] #522(park link dedup): missing fixture corpus: %s\n' "$corpus"
+        return
+    fi
+
+    local output count
+    set +e
+    output=$(bash "$LINT_ADR" "$corpus" 2>&1)
+    count=$(printf '%s\n' "$output" | grep -c "ADR-20261298-park-missing")
+    set -e
+
+    total=$((total + 1))
+    if [ "$count" -eq 1 ]; then
+        printf '[PASS] #522(park link dedup): リンク形式 park dangling は1回のみ報告（count=%d）\n' "$count"
+        passed=$((passed + 1))
+    else
+        printf '[FAIL] #522(park link dedup): リンク形式 park dangling は1回報告を期待したが %d 回\n  output:\n%s\n' "$count" "$output"
+        failed=$((failed + 1))
+    fi
+}
+
+run_layer4_park_link_dedup
+
 run_real_corpus_clean() {
     local corpus="$REPO_ROOT/docs/adr"
 


### PR DESCRIPTION
## 概要

ADR drift-lint（`scripts/lint-adr.sh`）に**レイヤ4**を追加し、有効ADRの `## 関連ADR`（`Related:`）／`## 保留した決定`（パーク欄）が指す ADR 参照先が**退役**（validity=上書き済み/廃止済み）または**非存在**（dangling）を指す場合に違反として報告する。参照先識別子の抽出を**書式非依存**（行頭バレット有無・markdown リンク形式有無を問わず先頭 stem を取る）に一般化し、#527（ADR-20260720-4 §3）が要件定義した dangling／パーク欄の参照妥当性検査を同一基盤へ統合した。

Closes #522

## 対応 Issue AC

| AC | 内容 | 検証 |
|---|---|---|
| AC1 | 有効ADRのRelatedが退役ADRを指すと違反 | invalid/18(バレット無)・19(リンク) |
| AC2 | stem抽出が書式非依存（穴1・穴2） | invalid/18・19 ＋ valid/06（全4書式で誤検出なし）|
| AC3 | 4種invalid fixtureテスト追加・パス | invalid/18/19/20/21 |
| AC4 | 実docs/adrがexit 0維持 | run_real_corpus_clean |
| AC5 | ヘッダ＋fixtureへ成文化・新規ADRなし・#491決定2遡及改稿なし | ヘッダコメント ＋ run_layer4_header_spec（必須アサート）|
| AC6 | Related/park欄の非存在参照でdangling違反 | invalid/20（Related）・21（park）|
| AC7 | パーク欄はdangling検査のみ（退役非適用＝J4）| valid/06（park→退役(存在)が違反にならない）|
| AC8 | 解決不能な参照先はfail-safe（dangling）| invalid/20 |
| AC9 | 検査有効化前に現行corpusがexit 0（Task1の短縮参照展開含む）| Task1コミット ＋ run_real_corpus_clean |

## 主な設計判断（Issue精査・プランで確定）

- **J1**: dangling検査のfull slug完全一致（§3）を満たすため、ADR-20260606の短縮参照2件（`ADR-20260602`/`ADR-20260602-2`）をfull slugへ正規化（先行コミット `fe74f0f`）。略記の正規化で参照の意味は不変。
- **J2**: 双方向性（レイヤ3）とは別不変条件のため**新レイヤ4**として独立追加。
- **J4**: パーク欄は**dangling検査のみ**（退役は非適用）。凍結スナップショットは後から編集不能で、参照先の後発退役で修復不能な違反を作らないため（§3の双方向非強制と同型）。Issue AC7 もこの決定へ細分化済み。
- **成文化先**: 判定単位はどのADRにも成文化されていないため、lint実装＋fixtureを正とする（新規ADRなし。#491決定2の遡及改稿なし）。決定出典はADR-20260720-4 §3。

## セルフレビュー実施済み

- 周回数: 1（実装 → 検証 → code-reviewerレビュー → 修正）
- 修正ブロッカー数: 1

### 修正した指摘

| 重大度 | 指摘 | 対応 | コミット |
|---|---|---|---|
| ブロッカー | `extract_park_adr_refs` がリンク形式パーク参照（`[stem](./stem.md)`）で同一stemを二重抽出しdangling違反を二重報告 | ファイル内dedupを追加。invalid/21をリンク形式へ変え、1回のみ報告することを検証する回帰テスト（run_layer4_park_link_dedup）を追加 | `fa4016c` |

### 改善提案（未対応・レビュアー判断委ね）

- **source scope の解釈**: dangling／退役検査の source を有効ADRに限定している。ADR-20260720-4 §3 は検査対象を「front-matterを持つADR」と広く書くが、退役（凍結）ADRは編集不能で修復不能な違反を課さないため、及び提案中・却下ADRの参照は未確定のため、有効ADRに絞った（Issue #522タイトル「有効ADRの…」に一致）。根拠はヘッダコメントに明記済み。§3文言との差を承知の上での判断。§3準拠へ広げるべきか要判断。
- **複数stem/行の2件目以降**: 1つの`Related:`行にADRが複数列挙される場合、先頭stemのみ検査し2件目以降はすり抜ける。これは#491決定2「判定単位＝先頭stem」を忠実に継承したもので本PRのスコープ外（決定2の遡及改稿はIssue制約で禁止）。将来Issue化の候補。

## テスト

- `bash scripts/test-lint-adr.sh` → **83/83 パス**（63→83、+20）
- `bash scripts/lint-adr.sh docs/adr` → **exit 0**

## スコープ外（本PRに含めない）

- 検査の実行契機（PreToolUseフック配線。#476の領分）
- 既存退役参照の是正そのもの（#491/PR #521で実施済み）
- `Related:`双方向性検査（一方向は合法）、パークのopen/resolved状態、Issue番号参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)
