### PR TITLE
docs: worktree での自動起動の射程を実測へ揃える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Claude Code向けの汎用スキルライブラリ。プロジェクト固有の
 
 ```bash
 ./setup-local.sh          # dev-workflow と adr のプラグインを --plugin-dir で読み込んで起動
-mise trust && mise install # 初回のみ。テストフレームワーク（bats）を版固定で導入する
+mise trust && mise install # チェックアウト（worktree 含む）ごとに一度。テストフレームワーク（bats）を版固定で導入する
 bash scripts/run-tests.sh # テストと検査器を一括実行する
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cp plugins/dev-workflow/skills/refine-issue/references/dor-default.md /path/to/y
 
 `claude --plugin-dir ./plugins/dev-workflow --plugin-dir ./plugins/adr` で両プラグインを読み込んだClaude Codeが起動します。各スキルは `/dev-workflow:{skill-name}`・`/adr:{skill-name}` のスコープ付き呼び出しで利用できます。
 
-テストと検査器は `bash scripts/run-tests.sh` で一括実行します（初回のみ `mise trust && mise install` が必要です）。実行経路の詳細は [docs/development/test-execution.md](docs/development/test-execution.md) を参照してください。
+テストと検査器は `bash scripts/run-tests.sh` で一括実行します（`mise trust && mise install` がチェックアウトごとに一度必要です。worktree も別のチェックアウトとして扱われます）。実行経路の詳細は [docs/development/test-execution.md](docs/development/test-execution.md) を参照してください。
 
 ## ライセンス
 

--- a/docs/development/test-execution.md
+++ b/docs/development/test-execution.md
@@ -26,7 +26,7 @@ runner は commit ゲート（`scripts/hooks/pre-commit-gate.sh`）から起動�
 
 ### git worktree で作業する場合
 
-本リポジトリの作業は git worktree 上で行うことが多い。**この経路でも自動起動は働き、検査対象になるのは worktree のツリーである**（実測は §8）。ただしそれが成り立つのはゲート側の仕掛けによるものであり、worktree 固有の注意も2点ある。
+本リポジトリの作業は git worktree 上で行うことが多い。**この経路でも自動起動は働き、検査対象になるのは worktree のツリーである**（`EnterWorktree` で入った worktree セッションでの実測。詳細は §8）。ただしそれが成り立つのはゲート側の仕掛けによるものであり、worktree 固有の注意も2点ある。
 
 **検査対象はゲートが git コンテキストから解決する。** `.claude/settings.json` のフックは `${CLAUDE_PROJECT_DIR}` 配下のゲートを起動し、同変数は project root（既定のチェックアウト）を指す。ゲートがそのまま `CLAUDE_PROJECT_DIR` を検査対象にすると、走るのは**コミット対象ではない別のツリー**に対する検査になり、project root が緑なら worktree の変更内容と無関係に通ってしまう。そこでゲートは「コミットが実際に走る git コンテキスト」から検査対象を解決する。候補を上から順に試し、git のトップレベルが取れ、かつそこに runner が在る最初のものを採る。
 

--- a/docs/development/test-execution.md
+++ b/docs/development/test-execution.md
@@ -69,9 +69,11 @@ mise exec -- bats --count scripts/tests/*.bats
 テストフレームワークは bats-core であり、版は `mise.toml` で固定している。
 
 ```bash
-mise trust     # 初回のみ。未信頼のまま mise は mise.toml を読まない
+mise trust     # チェックアウトごとに一度。未信頼のまま mise は mise.toml を読まない
 mise install   # bats 1.14.0 が入る
 ```
+
+`mise trust` の信頼はディレクトリ単位で効く。project root を信頼していても、新しく作った worktree は未信頼のままであり、そこで初めて作業するときに再度必要になる（§2 の注意2）。
 
 runner は bats を **`mise exec` 優先・PATH フォールバック**の順で解決する。版固定を効かせつつ、mise を使わない環境での手動実行経路を残すためである。
 

--- a/docs/development/test-execution.md
+++ b/docs/development/test-execution.md
@@ -36,9 +36,9 @@ runner は commit ゲート（`scripts/hooks/pre-commit-gate.sh`）から起動�
 
 どの候補でも解決できなければ exit 2 とする（fail-closed）。runner の実在を条件に含めるのは、無関係なリポジトリで作業しているときに候補1・2 がそちらを指しても、本ゲートがその commit を巻き込んで止めないためである。
 
-実測では、この解決の結果として worktree のツリーが検査対象になった。候補1が project root を指していれば project root が選ばれるはずである（git のトップレベルであり runner も在るため、候補2 へ進まない）。そうならなかったことから、**候補1は project root を指していない**と言える。候補1と候補2 のどちらで解決したかは切り分けていない。観測される結果はどちらでも同じであるため、機構は断定しない。
+実測では、この解決の結果として worktree のツリーが検査対象になった。候補1が project root のツリー内のいずれかを指していれば、そこで確定していたはずである。ゲートは候補を `git -C <候補> rev-parse --show-toplevel` に掛けるため、指しているのがサブディレクトリであってもトップレベルは project root に解決され、runner も在るため候補2 へ進まない。そうならなかったことから、**候補1は project root のツリー内のどこも指していない**と言える。候補1と候補2 のどちらで解決したかは切り分けていない。観測される結果はどちらでも同じであるため、機構は断定しない。
 
-**注意1: 起動されるゲートの実体は project root 側のものである。** フックのコマンドが `${CLAUDE_PROJECT_DIR}` 配下を指すため、worktree 側の `scripts/hooks/pre-commit-gate.sh` は呼ばれない（診断用に「必ず exit 2」で終わるゲートを worktree へ置いても commit が通ることを実測した）。検査対象は worktree でも、**判定を下すコードは project root のものである**。したがってゲート自体を改修する場合、その変更は自動経路では検証されない。stdin へ PreToolUse の JSON を投入する形で手元から確かめる（コマンドの形は §8）。
+**注意1: 起動されるゲートの実体は project root 側のものである。** フックのコマンドが `${CLAUDE_PROJECT_DIR}` 配下を指すため、worktree 側の `scripts/hooks/pre-commit-gate.sh` は呼ばれない（診断用に「必ず exit 2」で終わるゲートを worktree へ置いても commit が通ることを実測した）。ただし **project root 側なのはゲート本体だけである**。ゲートは解決したツリーへ `cd` してから runner を相対パスで起動するため、その配下で走る runner・テスト・検査器はいずれも worktree 側のものになる（§8 のマーカー観測）。したがって自動経路で検証されないのは `pre-commit-gate.sh` 自身の改修に限る。その場合は stdin へ PreToolUse の JSON を投入する形で手元から確かめる（コマンドの形は §8）。
 
 **注意2: worktree ごとに `mise trust` が要る。** `mise` の信頼はディレクトリ単位であり、project root を信頼していても新しく作った worktree は未信頼のままである。この状態では `mise exec` 経由で bats を解決できない。PATH にも bats が無ければ runner は非0で終わり（§4 の fail-closed）、ゲートが exit 2 で commit をブロックする。§8 の実測はこの条件下のものである。stderr に導入（`mise install`）と信頼（`mise trust`）の案内が出るので、それに従う。fail-closed が意図どおり働いた結果であり、異常ではない。
 

--- a/docs/development/test-execution.md
+++ b/docs/development/test-execution.md
@@ -26,7 +26,7 @@ runner は commit ゲート（`scripts/hooks/pre-commit-gate.sh`）から起動�
 
 ### git worktree で作業する場合
 
-本リポジトリの作業は git worktree 上で行うことが多い。**この経路でも自動起動は働き、検査対象になるのは worktree のツリーである**（`EnterWorktree` で入った worktree セッションでの実測。詳細は §8）。ただしそれが成り立つのはゲート側の仕掛けによるものであり、worktree 固有の注意も2点ある。
+本リポジトリの作業は git worktree 上で行うことが多い。**この経路でも自動起動は働き、検査対象になるのは worktree のツリーである**（`EnterWorktree` で入った worktree セッションでの実測。詳細は §8）。ただし検査対象が worktree になるのはゲート側の仕掛けによるものであり、worktree 固有の注意も2点ある。
 
 **検査対象はゲートが git コンテキストから解決する。** `.claude/settings.json` のフックは `${CLAUDE_PROJECT_DIR}` 配下のゲートを起動し、同変数は project root（既定のチェックアウト）を指す。ゲートがそのまま `CLAUDE_PROJECT_DIR` を検査対象にすると、走るのは**コミット対象ではない別のツリー**に対する検査になり、project root が緑なら worktree の変更内容と無関係に通ってしまう。そこでゲートは「コミットが実際に走る git コンテキスト」から検査対象を解決する。候補を上から順に試し、git のトップレベルが取れ、かつそこに runner が在る最初のものを採る。
 
@@ -40,7 +40,7 @@ runner は commit ゲート（`scripts/hooks/pre-commit-gate.sh`）から起動�
 
 **注意1: 起動されるゲートの実体は project root 側のものである。** フックのコマンドが `${CLAUDE_PROJECT_DIR}` 配下を指すため、worktree 側の `scripts/hooks/pre-commit-gate.sh` は呼ばれない（診断用に「必ず exit 2」で終わるゲートを worktree へ置いても commit が通ることを実測した）。検査対象は worktree でも、**判定を下すコードは project root のものである**。したがってゲート自体を改修する場合、その変更は自動経路では検証されない。stdin へ PreToolUse の JSON を投入する形で手元から確かめる（コマンドの形は §8）。
 
-**注意2: worktree ごとに `mise trust` が要る。** `mise` の信頼はディレクトリ単位であり、project root を信頼していても新しく作った worktree は未信頼のままである。この状態では bats を解決できず、runner が非0で終わり、ゲートが exit 2 で commit をブロックする。stderr に導入（`mise install`）と信頼（`mise trust`）の案内が出るので、それに従う。fail-closed が意図どおり働いた結果であり、異常ではない。
+**注意2: worktree ごとに `mise trust` が要る。** `mise` の信頼はディレクトリ単位であり、project root を信頼していても新しく作った worktree は未信頼のままである。この状態では `mise exec` 経由で bats を解決できない。PATH にも bats が無ければ runner は非0で終わり（§4 の fail-closed）、ゲートが exit 2 で commit をブロックする。§8 の実測はこの条件下のものである。stderr に導入（`mise install`）と信頼（`mise trust`）の案内が出るので、それに従う。fail-closed が意図どおり働いた結果であり、異常ではない。
 
 `plugins/adr/hooks/adr-commit-gate` は別のゲートであり、`lint-adr.sh` を `docs/adr` へ掛けるだけで runner を呼ばない。この役割分離は意図的なものであり、本経路とは独立している。
 
@@ -83,7 +83,7 @@ runner は bats を **`mise exec` 優先・PATH フォールバック**の順で
 $ bash scripts/run-tests.sh
 run-tests: bats を解決できません（mise exec・PATH のいずれでも見つからない）
   導入: mise install   （リポジトリ直下の mise.toml が版を固定する）
-  信頼: mise trust     （初回のみ。未信頼のまま mise は設定を読まない）
+  信頼: mise trust     （チェックアウトごとに一度。未信頼のまま mise は設定を読まない）
 $ echo $?
 1
 ```
@@ -216,5 +216,5 @@ FAILED: 1/2 suites (6s) -- bats
 - **2026-08-01（#653）**: worktree セッションからハーネス経由（Claude Code の Bash ツールで `git commit --allow-empty` を打つ形）で観測した。`EnterWorktree` で入った worktree から2回実施し、いずれも同じ結果。
   - 観測手段は2系統。`ps -eo pid=,args=` を 0.05 秒間隔でポーリングして `pre-commit-gate.sh` / `run-tests.sh` / `bats` のプロセスを拾い `readlink /proc/<pid>/cwd` で cwd を読む方法と、worktree 側の `scripts/run-tests.sh` 冒頭にのみ `$PWD` を追記するマーカーを一時的に仕込む方法（観測後に `git restore` で戻す）。
   - **ゲートは発火する**。起動されたのは project root 側の `pre-commit-gate.sh` であり、その配下で `bash scripts/run-tests.sh` が **cwd=worktree** で走った。worktree 側マーカーも `PWD=worktree` で発火した。観測期間中、cwd が project root のプロセスは1つも現れていない。所要は約6.2秒（プロセス初出から最終出現まで）、commit は exit 0 で通った。
-  - **未信頼 worktree での fail-closed**: 1回目は worktree の `mise.toml` が未信頼で bats を解決できず、runner が非0、ゲートが exit 2 で commit をブロックした。`mise trust --show` で project root=trusted / worktree=untrusted を確認。`mise trust` 後に上記の緑になった。
+  - **未信頼 worktree での fail-closed**: 1回目は worktree の `mise.toml` が未信頼で bats を解決できず、runner が非0、ゲートが exit 2 で commit をブロックした。runner は `mise exec` に失敗すると PATH へフォールバックする（§4）ため、この環境では PATH 上にも `bats` が無かったことになる。`mise trust --show` で project root=trusted / worktree=untrusted を確認。`mise trust` 後に上記の緑になった。
   - この観測により、#645 時点の §2 の記述（worktree では自動起動が働かないため手動実行が要る）が誤りであることが確定した。

--- a/docs/development/test-execution.md
+++ b/docs/development/test-execution.md
@@ -26,9 +26,9 @@ runner は commit ゲート（`scripts/hooks/pre-commit-gate.sh`）から起動�
 
 ### git worktree で作業する場合
 
-本リポジトリの作業は git worktree 上で行うことが多い。ここには**フックの起動と検査対象の解決という2段の落とし穴**がある。
+本リポジトリの作業は git worktree 上で行うことが多い。**この経路でも自動起動は働き、検査対象になるのは worktree のツリーである**（実測は §8）。ただしそれが成り立つのはゲート側の仕掛けによるものであり、worktree 固有の注意も2点ある。
 
-**1段目（検査対象の解決）はゲート側で塞いである。** `.claude/settings.json` のフックは `${CLAUDE_PROJECT_DIR}` 配下のゲートを起動し、同変数は project root（既定のチェックアウト）を指す。ゲートがそのまま `CLAUDE_PROJECT_DIR` を検査対象にすると、走るのは**コミット対象ではない別のツリー**に対する検査になり、project root が緑なら worktree の変更内容と無関係に通ってしまう。そこでゲートは「コミットが実際に走る git コンテキスト」から検査対象を解決する。候補を上から順に試し、git のトップレベルが取れ、かつそこに runner が在る最初のものを採る。
+**検査対象はゲートが git コンテキストから解決する。** `.claude/settings.json` のフックは `${CLAUDE_PROJECT_DIR}` 配下のゲートを起動し、同変数は project root（既定のチェックアウト）を指す。ゲートがそのまま `CLAUDE_PROJECT_DIR` を検査対象にすると、走るのは**コミット対象ではない別のツリー**に対する検査になり、project root が緑なら worktree の変更内容と無関係に通ってしまう。そこでゲートは「コミットが実際に走る git コンテキスト」から検査対象を解決する。候補を上から順に試し、git のトップレベルが取れ、かつそこに runner が在る最初のものを採る。
 
 1. PreToolUse の JSON が載せる `cwd`（ツール実行時の作業ディレクトリ）
 2. フックプロセス自身の cwd
@@ -36,7 +36,11 @@ runner は commit ゲート（`scripts/hooks/pre-commit-gate.sh`）から起動�
 
 どの候補でも解決できなければ exit 2 とする（fail-closed）。runner の実在を条件に含めるのは、無関係なリポジトリで作業しているときに候補1・2 がそちらを指しても、本ゲートがその commit を巻き込んで止めないためである。
 
-**2段目（フックの起動そのもの）は塞げていない。** worktree で開いたセッションからは、そもそもフックが worktree 側のゲートを呼ばないことがある（診断用に「必ず exit 2」で終わるゲートを worktree へ置いても commit が通ることを実測した。フックのコマンドが `${CLAUDE_PROJECT_DIR}` 配下の実体を指すためである）。**この経路では自動起動が働かないため、runner の手動実行が要る。**
+実測では、この解決の結果として worktree のツリーが検査対象になった。候補1が project root を指していれば project root が選ばれるはずである（git のトップレベルであり runner も在るため、候補2 へ進まない）。そうならなかったことから、**候補1は project root を指していない**と言える。候補1と候補2 のどちらで解決したかは切り分けていない。観測される結果はどちらでも同じであるため、機構は断定しない。
+
+**注意1: 起動されるゲートの実体は project root 側のものである。** フックのコマンドが `${CLAUDE_PROJECT_DIR}` 配下を指すため、worktree 側の `scripts/hooks/pre-commit-gate.sh` は呼ばれない（診断用に「必ず exit 2」で終わるゲートを worktree へ置いても commit が通ることを実測した）。検査対象は worktree でも、**判定を下すコードは project root のものである**。したがってゲート自体を改修する場合、その変更は自動経路では検証されない。stdin へ PreToolUse の JSON を投入する形で手元から確かめる（コマンドの形は §8）。
+
+**注意2: worktree ごとに `mise trust` が要る。** `mise` の信頼はディレクトリ単位であり、project root を信頼していても新しく作った worktree は未信頼のままである。この状態では bats を解決できず、runner が非0で終わり、ゲートが exit 2 で commit をブロックする。stderr に導入（`mise install`）と信頼（`mise trust`）の案内が出るので、それに従う。fail-closed が意図どおり働いた結果であり、異常ではない。
 
 `plugins/adr/hooks/adr-commit-gate` は別のゲートであり、`lint-adr.sh` を `docs/adr` へ掛けるだけで runner を呼ばない。この役割分離は意図的なものであり、本経路とは独立している。
 
@@ -205,5 +209,10 @@ FAILED: 1/2 suites (6s) -- bats
     - 期待リストを復元 → runner が exit 0、ゲートが exit 0。
   - この失敗は Issue #645 の発端となった検知漏れ（`manage-adr/references/` へファイルが増えたのに期待リストへ未登録）と同一の型である。
   - **検査対象ツリーの解決**（§2「git worktree で作業する場合」）: JSON の `cwd` に worktree を、`CLAUDE_PROJECT_DIR` に project root を与えた状態で、worktree 側だけを壊すと exit 2、戻すと exit 0 になることを確認。`cwd` を持たない JSON・git 外の cwd・runner を持たないツリーの各分岐についても、フォールバック順と fail-closed（exit 2）を確認した。
-  - **観測方法についての注記**: 上記のゲート観測は PreToolUse の JSON を stdin へ直接投入する形で行った。ハーネス経由（Claude Code の Bash ツールで実際に `git commit` を打つ形）の実地確認は、git worktree 内のセッションからは取れない（§2 の2段目）。ゲートが受け取る入力は PreToolUse の JSON そのものであり、投入経路はゲートの判定に影響しないため、ブロック挙動の証拠としては等価である。
+  - **観測方法についての注記**: 上記のゲート観測は PreToolUse の JSON を stdin へ直接投入する形で行った。ゲートが受け取る入力は PreToolUse の JSON そのものであり、投入経路はゲートの判定に影響しないため、ブロック挙動の証拠としては等価である。ハーネス経由での実地確認は #653 で別途行った（下記）。
   - **bats 解決失敗時の fail-closed**: `mise` も PATH 上の `bats` も見えない環境（`env -i PATH=/usr/bin:/bin`）で runner を起動すると exit 1 で終わり、導入手順（`mise install` / `mise trust`）が stderr に出ることを確認。
+- **2026-08-01（#653）**: worktree セッションからハーネス経由（Claude Code の Bash ツールで `git commit --allow-empty` を打つ形）で観測した。`EnterWorktree` で入った worktree から2回実施し、いずれも同じ結果。
+  - 観測手段は2系統。`ps -eo pid=,args=` を 0.05 秒間隔でポーリングして `pre-commit-gate.sh` / `run-tests.sh` / `bats` のプロセスを拾い `readlink /proc/<pid>/cwd` で cwd を読む方法と、worktree 側の `scripts/run-tests.sh` 冒頭にのみ `$PWD` を追記するマーカーを一時的に仕込む方法（観測後に `git restore` で戻す）。
+  - **ゲートは発火する**。起動されたのは project root 側の `pre-commit-gate.sh` であり、その配下で `bash scripts/run-tests.sh` が **cwd=worktree** で走った。worktree 側マーカーも `PWD=worktree` で発火した。観測期間中、cwd が project root のプロセスは1つも現れていない。所要は約6.2秒（プロセス初出から最終出現まで）、commit は exit 0 で通った。
+  - **未信頼 worktree での fail-closed**: 1回目は worktree の `mise.toml` が未信頼で bats を解決できず、runner が非0、ゲートが exit 2 で commit をブロックした。`mise trust --show` で project root=trusted / worktree=untrusted を確認。`mise trust` 後に上記の緑になった。
+  - この観測により、#645 時点の §2 の記述（worktree では自動起動が働かないため手動実行が要る）が誤りであることが確定した。

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 # 開発ツールの版固定。
 #
 # 導入: `mise install`
-# 信頼: `mise trust`（初回のみ。未信頼のまま mise は本ファイルを読まない）
+# 信頼: `mise trust`（チェックアウトごとに一度。未信頼のまま mise は本ファイルを読まない）
 #
 # bats — scripts/tests/*.bats を実行するテストフレームワーク。
 # scripts/run-tests.sh が `mise exec` 経由で起動し、解決できない場合は非0で終わる

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -60,7 +60,7 @@ resolve_bats() {
     cat >&2 <<'MSG'
 run-tests: bats を解決できません（mise exec・PATH のいずれでも見つからない）
   導入: mise install   （リポジトリ直下の mise.toml が版を固定する）
-  信頼: mise trust     （初回のみ。未信頼のまま mise は設定を読まない）
+  信頼: mise trust     （チェックアウトごとに一度。未信頼のまま mise は設定を読まない）
 MSG
     return 1
 }


### PR DESCRIPTION
Closes #653

## 概要

`docs/development/test-execution.md` §2「git worktree で作業する場合」の記述を実測へ揃える。従来の記述は「worktree セッションでは自動起動が働かないため runner の手動実行が要る」としていたが、実際には発火し、検査対象として解決されるのは worktree のツリーだった。

## 実測

`EnterWorktree` で入った worktree セッションから、Claude Code の Bash ツール経由で `git commit --allow-empty` を実行した。観測手段は2系統。

- `ps -eo pid=,args=` を 0.05 秒間隔でポーリングして `pre-commit-gate.sh` / `run-tests.sh` / `bats` のプロセスを拾い、`readlink /proc/<pid>/cwd` で cwd を読む
- worktree 側の `scripts/run-tests.sh` 冒頭にのみ `$PWD` を追記するマーカーを一時的に仕込む（観測後に `git restore` で戻した）

2回実施し、いずれも同じ結果を得た。

- **ゲートは発火する**。起動されたのは project root 側の `pre-commit-gate.sh` であり、その配下で `bash scripts/run-tests.sh` が **cwd=worktree** で走った。worktree 側マーカーも `PWD=worktree` で発火した。観測期間中、cwd が project root のプロセスは1つも現れていない
- 所要は約6.2秒。commit は exit 0 で通った
- 1回目は worktree の `mise.toml` が未信頼で bats を解決できず、runner が非0、ゲートが exit 2 で commit をブロックした。`mise trust --show` で project root=trusted / worktree=untrusted を確認。`mise trust` 後に緑になった

## 変更内容

### §2「git worktree で作業する場合」

- 「フックの起動と検査対象の解決という2段の落とし穴」という枠組みを撤去した。2段目は落とし穴ではない
- 冒頭を「この経路でも自動起動は働き、検査対象になるのは worktree のツリーである」に改めた
- 解決順（候補1: JSON の `cwd` → 候補2: フックプロセスの cwd → 候補3: `CLAUDE_PROJECT_DIR`）について、候補1が project root を指していれば候補2 へ進まず project root が選ばれていたはずであることから、**候補1は project root を指していない**と述べた。候補1と候補2 のどちらで解決したかは切り分けていないため断定していない
- 「フックが worktree 側のゲートを呼ばない」という従来の記述は正しいため残した。ただし位置付けを改め、検査対象は worktree でも判定を下すコードは project root のものであること、その帰結としてゲート自体の改修は自動経路では検証されないことを明示した
- worktree ごとに `mise trust` が要ることと、未信頼時の症状（ゲートが exit 2、導入・信頼の案内が stderr に出る）を追加した

### §4「セットアップ」

- `mise trust` の注記を「初回のみ」から「チェックアウトごとに一度」へ改め、信頼がディレクトリ単位で効くことと §2 注意2 へのポインタを足した。§2 に worktree ごとの `mise trust` を書いた結果、同一文書内で食い違っていたため
- 同節の fail-closed 出力例に含まれる「初回のみ」は `scripts/run-tests.sh` の stderr の写しであり、当初はスクリプト側の文言変更をスコープ外として据え置いたが、レビュー指摘1 を受けて本 PR へ含めた（下記「レビュー指摘への対応」）

### §8「動作確認済み」

- 「ハーネス経由の実地確認は worktree 内のセッションからは取れない」という記述を除いた。本 PR の観測がそれ自体、worktree セッションからのハーネス経由の観測である
- 今回の実測を日付・Issue 番号つきで追記した

## セルフレビューで入れた修正

- §2 冒頭の「検査対象になるのは worktree のツリーである」を無条件の断定で書いていたため、実測条件（`EnterWorktree` で入ったセッション）を括弧内へ明示した。解決順は cwd 依存であり、条件を伏せた一般化は本 Issue が正そうとした誤りと同じ型になる

## レビュー指摘への対応

### 1巡目・指摘1: 「初回のみ」の残存（修正価値: 高）→ 5箇所すべて本 PR で揃えた

`CLAUDE.md:13` / `README.md:106` / `mise.toml:4` / `scripts/run-tests.sh:63` と、その写しである §4 の fail-closed 出力例を「チェックアウトごとに一度」へ揃えた。

レビューは3箇所（`CLAUDE.md` / `README.md` / `mise.toml`）を本 PR で、`run-tests.sh:63` と §4 出力例を別 Issue へ送る案を推していたが、指摘が述べる実害経路——worktree で commit がブロックされた開発者が注意2 の指示どおり stderr を読み、そこで「初回のみ」を見て原因に到達できない——の中心はその stderr 自身である。3箇所だけを揃えると、注意2 が案内する先の穴が残る。`run-tests.sh` の変更は文言1語の置換であり、当該文言に依存するテストは無く、判定・出力構造には触れていない。

`CLAUDE.md` は「チェックアウト（worktree 含む）ごとに一度」、`README.md` は「worktree も別のチェックアウトとして扱われます」を添え、読み手が自分の状況を当てはめられる形にした。

### 1巡目・指摘2: 注意2 が PATH フォールバックの条件を落としている（修正価値: 中）→ 条件を補った

「この状態では bats を解決できず」を「`mise exec` 経由で bats を解決できない。PATH にも bats が無ければ runner は非0で終わり（§4 の fail-closed）」へ改め、§8 の実測がその条件下のものであることを添えた。

あわせて §8 の実測記録（2026-08-01 #653）にも同じ演繹を書き足した。従来は「未信頼で bats を解決できず、runner が非0」とだけ記していたため、§2 で述べる実測条件の裏付けが文書内に無かった。runner が PATH フォールバックを持つ以上、fail-closed に至った事実からその環境の PATH に `bats` が無かったことが導かれる。

### 1巡目・指摘3: 「それが成り立つのは」の指示対象（修正価値: 低）→ 後半へ限定した

「ただしそれが成り立つのはゲート側の仕掛けによる」を「ただし検査対象が worktree になるのはゲート側の仕掛けによる」へ改めた。ゲート側の仕掛けが説明するのは検査対象の解決だけであり、フックが発火すること自体はハーネス側の挙動でゲートは関与しない。

### 2巡目・指摘1: 注意1 の「判定を下すコードは project root」が範囲を超えている（修正価値: 高）→ 主語をゲート本体へ限定した

指摘のとおり、project root 側なのはゲート本体だけである。実体で確認した。

- `scripts/hooks/pre-commit-gate.sh:84-88` — 解決した `target` へ `cd` してから `bash scripts/run-tests.sh` を相対パスで起動する
- `scripts/run-tests.sh:15-17` — `BASH_SOURCE` から `REPO_ROOT` を決めて `cd` する。`:26` の `TESTS_DIR`、`:125` の `validate-skills` 起動もそこを基点にする

したがって runner・bats のテスト・検査器はいずれも worktree 側で走る。従来の記述は §8 のマーカー観測（worktree 側マーカーが `PWD=worktree` で発火）と同一文書内で食い違っていた。

対比の主語をゲート本体へ限定し、「自動経路で検証されないのは `pre-commit-gate.sh` 自身の改修に限る」と射程を狭めた。指摘が述べるとおり、本 PR 自身がその経路に乗っている（`run-tests.sh` の stderr 文言変更は worktree での commit で実際に検証される）。

### 2巡目・参考: 候補1 の演繹の射程（修正価値: 低）→ 強い形へ書き換えた

ゲートは候補を `git -C <候補> rev-parse --show-toplevel` に掛けるため、候補1 が project root のサブディレクトリを指していても project root へ解決されて確定する。演繹から得られるのは「候補1 は project root のツリー内のどこも指していない」であり、従来の記述はそれより弱い言い方だった。結論の向きは変わらないが、機構の帰属を正確に書くことが本 PR の主題であるため強い形へ揃えた。

## 経緯

誤りの型は #645（PR #649）のときと同じで、限られた観測から機構を推論して結論を飛ばしたことにある。#653 は当初「フックは発火するが検査対象は project root のツリーである」という是正案を持っていたが、これも再現しなかったため、Issue 本文を実測へ差し替えたうえで本 PR を作成した。今回は解決したツリーそのものを直接観測して確定させ、切り分けていない部分は断定しない形で残している。

## スコープ外

- worktree 側のゲート実体が呼ばれないことへの対処（フック登録の変更等）
- `scripts/hooks/pre-commit-gate.sh` および `scripts/run-tests.sh` の**挙動**変更（`run-tests.sh` は指摘1 の対応で stderr の文言1語を置換したが、判定・解決順・出力構造には触れていない）
- 解決順の候補1と候補2 のどちらが効いているかの切り分け

## 検証

```
$ bash scripts/run-tests.sh
[test ] bats                 ... 76 tests, 0 failures (10s)
[check] validate-skills      ... ok (0s)
all suites passed (2 suites, 10s)
=== exit: 0 ===
```

文書とコメント・案内文言のみの変更であり、76ケースに増減はない。「初回のみ」が残る箇所が無いことを `grep -rn "初回のみ"` で確認した（一致0件）。
