### PR TITLE
docs: 配布境界の第3軸を据えた ADR を承認済みへ遷移させる

### DIFF
--- a/docs/adr/ADR-202608061516-01-distribution-boundary-inexecutability-test.md
+++ b/docs/adr/ADR-202608061516-01-distribution-boundary-inexecutability-test.md
@@ -1,6 +1,6 @@
 ---
-status: 提案中
-validity:
+status: 承認済み
+validity: 有効
 superseded-by:
 ---
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -48,3 +48,4 @@
 - [ADR-202608011354-01-adr-issuance-timing-and-naming-scope](./ADR-202608011354-01-adr-issuance-timing-and-naming-scope.md): ADR 起票のタイミングと命名規約の ADR 化基準
 - [ADR-202608011355-01-record-reference-principle](./ADR-202608011355-01-record-reference-principle.md): 記録は可変文書を現在の参照先として指さない
 - [ADR-202608011651-01-adr-value-precondition-criteria-in-operating-doc](./ADR-202608011651-01-adr-value-precondition-criteria-in-operating-doc.md): ADR の固有価値を却下代替に定めて起票の必要条件とし、粒度判定基準の項目と境界は運用文書へ委ねる
+- [ADR-202608061516-01-distribution-boundary-inexecutability-test](./ADR-202608061516-01-distribution-boundary-inexecutability-test.md): 配布境界の第3の判断軸に実行不能性テストを据える


### PR DESCRIPTION
## 概要

#657（PR #670）で起票した `ADR-202608061516-01`（配布境界の第3の判断軸に実行不能性テストを据える）を**承認済み**へ遷移させる。

#657 の AC9 が求めたのは**起票**であって承認ではないため、同 PR では `status: 提案中` で確定していた。本 PR は `manage-adr` の承認遷移を単独で適用する。

## 変更内容

`manage-adr` の承認遷移（`status: 承認済み`・`validity: 有効`、`superseded-by` は空のまま）に従う。本文は 1 文字も変えていない。

| ファイル | 変更 |
|---|---|
| `docs/adr/ADR-202608061516-01-distribution-boundary-inexecutability-test.md` | front-matter を `status: 提案中` / `validity:`（空）→ `status: 承認済み` / `validity: 有効` へ。`superseded-by` は空のまま |
| `docs/adr/index.md` | `validity` を変える操作のため `gen-adr-index.sh` で再生成。差分は当該 ADR の 1 行追加のみ |

## 遷移前の状態確認

`transitions.md` の実行ガード（承認は `status: 提案中` から行う）に従い、操作前に対象 ADR の現在状態を確認した。`status: 提案中` / `validity` 空 / `superseded-by` 空であり、承認の遷移元として正しい。

## 検証

| コマンド | 結果 |
|---|---|
| `bash plugins/adr/scripts/lint-adr.sh docs/adr` | **exit 0**（`manage-adr` が定める合否基準） |
| `bash scripts/run-tests.sh` | exit 0（bats 76 tests, 0 failures / validate-skills ok） |

index の再生成は差分を先に確認してから適用した（既存 50 行に対し当該 ADR の 1 行が追加されるのみで、他の行に変化なし）。

## セルフレビュー実施済み

- 周回数: 1
- 修正ブロッカー数: 0

front-matter の 2 行と index の 1 行以外に変更が無いこと、および ADR 本文が無改変であることを `git diff` で確認している。

Refs #657
