### PR TITLE
chore: growth プラグインを v0.2.0 へ（store 形式の変更を伴う機能追加）

### DIFF
--- a/plugins/growth/.claude-plugin/plugin.json
+++ b/plugins/growth/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "growth",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Claude Code向けの内省・学習プラグイン。セッションの学びを観測・検証し、配布物（skill / ルールファイル / ADR）として全利用者へ届ける。"
 }


### PR DESCRIPTION
## 概要

`plugins/growth` の版を `0.1.0` → `0.2.0` へ上げる。変更は `plugin.json` の1行のみ。

## 背景

`version` が `0.1.0` のまま据え置かれており、その間に `plugins/growth/` へ **71コミット**が入っていた。配布経路（マーケットプレイスの cache）は版単位で解決するため、内容だけが進んで cache 側が旧版に固定される状態になっていた。

2026-08-08 のセッションで `/growth:capture` を起動したところ、実際に走ったのは cache の 0.1.0 で、リポジトリの現行版とは挙動が異なっていた。

| | cache 0.1.0（実際に走った） | リポジトリ現行版 |
|---|---|---|
| 書き込み先 | `captures.md` 単一ファイル | `captures-YYYY-MM-DD.md` 日付バケット |
| 検出器 | 予測誤差4種のみ | 予測誤差＋教示信号の2群 |
| エントリ項目 | `signal` / `session` / `status` | ＋ `origin` / `expected` / `actual` |

結果として観測11件が旧形式で書かれた。現行版の `distill` は `captures-*.md` をセグメント glob で列挙するため、この形式のままでは入力に入らない。

## MINOR とした理由

`0.1.0` 以降の主な差分は次のとおり。生観測 store の物理形式が変わるため PATCH ではなく MINOR とする。

- 生観測 store の日付バケット化（`captures-YYYY-MM-DD.md`）
- エントリの無状態化と、`distill` 側カーソルによる処理源選択
- 教示信号（選好・却下理由・目標表明・設計判断）の検出器追加
- `origin` / `expected` / `actual` の項目追加
- キャリア軸 spec の新設
- 配布物からの配布元参照の除去

## スコープ外

既存の単一 `captures.md` の移行は本 PR に含まない。`personal-store-spec.md`「表記規約」が「バケット化以前に生成された単一 `captures.md` は本 store 形式の対象外（#485 OUT・移行は手動）」と定めており、物理 store の移行は別途行う。

## 検証

- `jq . plugins/growth/.claude-plugin/plugin.json` が成功する
- `bash scripts/run-tests.sh` が終了コード0（bats 76件 / 0 failures、`validate-skills ok`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5pzdFqDaXbfg4dgMqTiUk
