### PR TITLE
test: remove bats report count drift for #710

### DIFF
--- a/docs/superpowers/plans/2026-08-10-issue-710-bats-drift-plan.md
+++ b/docs/superpowers/plans/2026-08-10-issue-710-bats-drift-plan.md
@@ -1,0 +1,112 @@
+# Issue #710 bats Drift Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** bats の異常系4サイトが `report` の差件数表示に依存せず、期待帰結ファイルの読込失敗を検出できるようにする。
+
+**Architecture:** 本体スクリプトと fixture は変更せず、既存 bats テストの report 検査だけを変更する。正常経路の report 出力を各異常経路の baseline として比較し、差件数の表示文言は面⑪のみに閉じ込める。
+
+**Tech Stack:** Bash、bats、mise、既存の `scripts/tests/helpers/common.bash` ヘルパー。
+
+## Global Constraints
+
+- `plugins/adr/scripts/adr-scoping-cases.sh` の振る舞いを変えない。
+- `scripts/fixtures/adr-scoping-cases/` 配下を変更しない。
+- 面⑪（18〜22c）の変更は行わない。
+- 09b・40a・40b・40c は `差 N 件` の文字列一致を判定に用いない。
+
+## Files and responsibilities
+
+- Modify: `scripts/tests/adr-scoping-cases-basic.bats` — 09b の正常 report baseline 比較とラベル修正。
+- Modify: `scripts/tests/adr-scoping-cases-edge.bats` — 40a／40b／40c の正常 report baseline 比較とラベル修正。
+- Do not modify: `plugins/adr/scripts/adr-scoping-cases.sh`、`scripts/fixtures/adr-scoping-cases/`。
+
+### Task 1: 09b の report 検査を baseline 比較へ変更
+
+**Files:**
+- Modify: `scripts/tests/adr-scoping-cases-basic.bats:241-257`
+
+**Interfaces:**
+- Consumes: `sc` helper、`$JUDGMENTS_DIR/valid-judgments.tsv`、`$CASES_DIR/valid`。
+- Produces: 09b が正常経路と `a=b`／`j=1.tsv` 経路の report 出力一致を検証する。
+
+- [ ] **Step 1: Write the failing test change**
+
+  09b の `*"差 2 件"*` 一致を削除し、通常パスで `sc report "$JUDGMENTS_DIR/valid-judgments.tsv" "$CASES_DIR/valid"` を実行して `baseline` を保存する。`a=b`／`j=1.tsv` の `$output` と `baseline` の一致を検証し、ラベルから差件数表現を除く。
+
+- [ ] **Step 2: Run the focused test to verify the intended assertion**
+
+  Run: `mise exec -- bats scripts/tests/adr-scoping-cases-basic.bats`
+
+  Expected: 09b の旧 assertion が残っていない状態で、basic suite が pass する。失敗する場合は report 出力取得方法または比較対象を修正する。
+
+- [ ] **Step 3: Run the focused suite again after cleanup**
+
+  Run: `mise exec -- bats scripts/tests/adr-scoping-cases-basic.bats`
+
+  Expected: `not ok` なし。
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add scripts/tests/adr-scoping-cases-basic.bats
+  git commit -m "test: remove report count drift from case 09b"
+  ```
+
+### Task 2: 40a／40b／40c の report 検査を baseline 比較へ変更
+
+**Files:**
+- Modify: `scripts/tests/adr-scoping-cases-edge.bats:32,178,186,196-231`
+
+**Interfaces:**
+- Consumes: `check_weird_tmpdir`、`sc` helper、valid judgments/cases fixtures。
+- Produces: 40a／40b／40c が正常経路と異常経路の report 出力一致を検証する。
+
+- [ ] **Step 1: Write the failing test change**
+
+  `check_weird_tmpdir` で通常の `report` 出力を baseline として取得し、異常な `$TMPDIR` の report 出力との一致を比較する。40c でも通常の題材集合パスの report 出力と特殊文字パスの出力を比較する。`差 2 件` の一致を削除し、ラベルを実際の性質（期待帰結読込を含む report 経路の同一性）に合わせる。
+
+- [ ] **Step 2: Run the focused test to verify the intended assertion**
+
+  Run: `mise exec -- bats scripts/tests/adr-scoping-cases-edge.bats`
+
+  Expected: edge suite が pass し、40a／40b／40c に `not ok` がない。
+
+- [ ] **Step 3: Run both affected suites**
+
+  Run: `mise exec -- bats scripts/tests/adr-scoping-cases-basic.bats scripts/tests/adr-scoping-cases-edge.bats`
+
+  Expected: 両 suite が pass する。
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add scripts/tests/adr-scoping-cases-edge.bats
+  git commit -m "test: remove report count drift from edge cases"
+  ```
+
+### Task 3: Issue AC と全体検証を確認
+
+**Files:**
+- Verify: `scripts/tests/adr-scoping-cases-basic.bats`
+- Verify: `scripts/tests/adr-scoping-cases-edge.bats`
+
+- [ ] **Step 1: Verify no affected site matches report count text**
+
+  Run: `rg -n '09b|40a|40b|40c|差 [0-9]+ 件|差2件' scripts/tests/adr-scoping-cases-basic.bats scripts/tests/adr-scoping-cases-edge.bats`
+
+  Expected: 09b／40a／40b／40c の assertion・ラベルに `差 N 件` 表現がない。面⑪など対象外の既存検査はこの確認から除外して判定する。
+
+- [ ] **Step 2: Run the complete test runner**
+
+  Run: `mise exec -- bash scripts/run-tests.sh`
+
+  Expected: exit 0、全 suite が ok、`not ok` なし。
+
+- [ ] **Step 3: Review the diff and AC checklist**
+
+  `git diff origin/main...HEAD` で変更が2つの bats ファイルと設計・計画文書に限定され、本体スクリプト・fixture・面⑪を変更していないことを確認する。AC 1〜5 をそれぞれ resolved と記録する。
+
+- [ ] **Step 4: Commit any final test-only cleanup**
+
+  最終検証で必要な修正があれば対象ファイルだけを stage し、既存コミット規約に従ってコミットする。修正がなければ追加コミットは作らない。

--- a/docs/superpowers/specs/2026-08-10-issue-710-bats-drift-design.md
+++ b/docs/superpowers/specs/2026-08-10-issue-710-bats-drift-design.md
@@ -1,0 +1,32 @@
+# Issue #710: bats 代理指標 drift 解消設計
+
+## 目的
+
+`main` の bats スイートを緑へ戻し、`report` の差件数が変わるたびに、差件数を検査対象としていない異常系テストが壊れる状態を解消する。
+
+## 対象と制約
+
+- 対象は `scripts/tests/adr-scoping-cases-basic.bats` の 09b と、`scripts/tests/adr-scoping-cases-edge.bats` の 40a／40b／40c。
+- `plugins/adr/scripts/adr-scoping-cases.sh` と fixture は変更しない。
+- 面⑪の差件数検査は、`report` の集計本文を検証する唯一のサイトとして維持する。
+
+## 採用案
+
+異常系4サイトでは `差 N 件` という表示文言を直接一致させない。正常経路で同じ `report` を実行した出力を baseline とし、各異常条件で得た出力が baseline と一致することを確認する。
+
+これにより、各サイトが本来検査している性質（`var=value` パス、異常な `$TMPDIR`、特殊文字を含む題材集合パス）と、期待帰結を読めることの確認を分離する。集計本文の表示文言だけを変更しても異常系4サイトは影響を受けず、期待帰結ファイルを読めない変異では異常経路と正常経路の出力が不一致になるため検出できる。
+
+## 実装方針
+
+1. 09b・40a/b・40c のラベルから旧来の差件数表現を除き、各サイトの検査対象を明記する。
+2. 09b と 40a/b は、異常条件を付けない同等の `report` 出力を取得し、異常条件下の出力と比較する。
+3. 40c は特殊文字を含む題材集合パスでの `report` 出力を、通常の題材集合パスでの出力と比較する。
+4. 既存の rc、プロンプト、診断内容の検査は維持する。
+
+## 検証
+
+- `mise exec -- bats scripts/tests/adr-scoping-cases-basic.bats`
+- `mise exec -- bats scripts/tests/adr-scoping-cases-edge.bats`
+- `mise exec -- bash scripts/run-tests.sh`
+- `scripts/tests/` 内の 09b・40a・40b・40c が `差 [0-9]+ 件` に一致させていないことを確認する。
+- 変更差分をレビューし、Issue #710 の受入条件を1件ずつ確認する。

--- a/scripts/tests/adr-scoping-cases-basic.bats
+++ b/scripts/tests/adr-scoping-cases-basic.bats
@@ -242,15 +242,14 @@ copy_valid_case_dir() {
     local eq_ok=1 eq_detail=""
     copy_valid_case_dir "$eq_parent/a=b"
     cp "$JUDGMENTS_DIR/valid-judgments.tsv" "$eq_parent/j=1.tsv"
+    sc report "$JUDGMENTS_DIR/valid-judgments.tsv" "$CASES_DIR/valid"
+    local baseline="$output"
+    [ "$status" -eq 0 ] || { eq_ok=0 eq_detail="baseline report: rc=$status / $output"; }
     sc_in "$eq_parent" validate 'a=b'
     [ "$status" -eq 0 ] || { eq_ok=0 eq_detail="validate: rc=$status / $output"; }
     sc_in "$eq_parent" report 'j=1.tsv' 'a=b'
     [ "$status" -eq 0 ] || { eq_ok=0 eq_detail="${eq_detail}${eq_detail:+ / }report: rc=$status"; }
-    # 判定記録TSV を読めていないと、期待帰結を読めていても差が消えて「差は無い」へ倒れる。
-    case "$output" in
-        *"差 2 件"*) ;;
-        *) eq_ok=0 eq_detail="${eq_detail}${eq_detail:+ / }report: 期待帰結との差が出ていない" ;;
-    esac
+    [ "$output" = "$baseline" ] || eq_ok=0 eq_detail="${eq_detail}${eq_detail:+ / }report: baseline と出力が一致しない"
     sc_stdout_in "$eq_parent" prompt "$DOC" CASE-A1 'a=b'
     if [ "$status" -ne 0 ] || [ ! -f "$output" ]; then
         eq_ok=0

--- a/scripts/tests/adr-scoping-cases-edge.bats
+++ b/scripts/tests/adr-scoping-cases-edge.bats
@@ -29,7 +29,7 @@ SCAN_ORDER_IDS="CASE-A1 CASE-ZZ CASE-M3 CASE-B2 CASE-Q9 CASE-D4"
 # ヒアドキュメントで逐語のまま持つ。
 LABEL_40A=$(
     cat <<'EOF'
-40a. prompt/validate/report（$TMPDIR に it's を含む）→ exit 0、trap が壊れず題材文・期待帰結も読める
+40a. prompt/validate/report（$TMPDIR に it's を含む）→ 通常環境と report 経路（期待帰結読込を含む）が一致する
 EOF
 )
 
@@ -175,16 +175,23 @@ make_awk_shim() {
     # 一時ファイルと awk を使うサブコマンドすべてに現れうるため、片方だけ試すと取りこぼす。
     check_weird_tmpdir "it's" "$LABEL_40A"
     check_weird_tmpdir 'back\slash' \
-        '40b. prompt/validate/report（$TMPDIR に back\slash を含む）→ exit 0、trap が壊れず題材文・期待帰結も読める'
+        '40b. prompt/validate/report（$TMPDIR に back\slash を含む）→ 通常環境と report 経路（期待帰結読込を含む）が一致する'
 
     # 題材集合ディレクトリのパスそのものに `&` と `\` が含まれる場合。
     # awk -v のエスケープ解釈で期待帰結ファイルを読めないと、report は無言で
     # 「差は無い」へ倒れる（診断ゼロで結論だけが反転する経路）。
     local weird_dir="$BATS_TEST_TMPDIR/weird/di&r\\x"
     copy_valid_case_dir "$weird_dir"
+    sc report "$JUDGMENTS_DIR/valid-judgments.tsv" "$CASES_DIR/valid"
+    local baseline_report_status="$status" baseline_report_output="$output"
     sc report "$JUDGMENTS_DIR/valid-judgments.tsv" "$weird_dir"
-    collect_run 0 '40c. report（題材集合ディレクトリのパスに & と \ を含む）→ 期待帰結を読み、差2件をそのまま出す' \
-        "CASE-A2 試行2 項目3: 期待 1 / 判定 0" "差 2 件"
+    local report_ok=1 report_detail=""
+    [ "$baseline_report_status" -eq 0 ] || report_ok=0 report_detail="通常環境 report: rc=$baseline_report_status"
+    [ "$status" -eq 0 ] || report_ok=0 report_detail="${report_detail}${report_detail:+ / }特殊文字パス report: rc=$status"
+    [ "$output" = "$baseline_report_output" ] || report_ok=0 report_detail="${report_detail}${report_detail:+ / }通常環境と特殊文字パスの report 出力が一致しない"
+    [ "$report_ok" -eq 1 ] \
+        && collect_ok '40c. report（題材集合ディレクトリのパスに & と \ を含む）→ 通常環境と report 経路（期待帰結読込を含む）が一致する' \
+        || collect_fail '40c. report（題材集合ディレクトリのパスに & と \ を含む）→ 通常環境と report 経路（期待帰結読込を含む）が一致する' "$report_detail"
     sc validate "$weird_dir"
     collect_run 0 '40d. validate（題材集合ディレクトリのパスに & と \ を含む）→ exit 0' \
         "題材集合の検査に通った"
@@ -216,17 +223,17 @@ check_weird_tmpdir() {
         rm -f "$path"
     fi
 
-    # validate と report も同じ $TMPDIR で通す。report は期待帰結との差まで出ること
-    # （一時ファイルを読めていれば差2件が出る）を見て、無言の結論反転を捕まえる。
+    # validate と report も同じ $TMPDIR で通す。report は通常環境の出力を baseline として
+    # 比較し、期待帰結の読込を含む経路の無言の結論反転を捕まえる。
     run env TMPDIR="$tmp" bash "$SUT" validate "$CASES_DIR/valid" </dev/null
     [ "$status" -eq 0 ] || ok=0 detail="${detail}${detail:+ / }validate: rc=$status / $output"
 
+    run bash "$SUT" report "$JUDGMENTS_DIR/valid-judgments.tsv" "$CASES_DIR/valid" </dev/null
+    local baseline_report_status="$status" baseline_report_output="$output"
     run env TMPDIR="$tmp" bash "$SUT" report "$JUDGMENTS_DIR/valid-judgments.tsv" "$CASES_DIR/valid" </dev/null
-    [ "$status" -eq 0 ] || ok=0 detail="${detail}${detail:+ / }report: rc=$status / $output"
-    case "$output" in
-        *"差 2 件"*) ;;
-        *) ok=0 detail="${detail}${detail:+ / }report: 期待帰結との差が出ていない（結論が無言で反転している）" ;;
-    esac
+    [ "$baseline_report_status" -eq 0 ] || ok=0 detail="${detail}${detail:+ / }通常環境 report: rc=$baseline_report_status"
+    [ "$status" -eq 0 ] || ok=0 detail="${detail}${detail:+ / }特殊文字 TMPDIR report: rc=$status / $output"
+    [ "$output" = "$baseline_report_output" ] || ok=0 detail="${detail}${detail:+ / }通常環境と特殊文字 TMPDIR の report 出力が一致しない"
 
     [ "$ok" -eq 1 ] && collect_ok "$label" || collect_fail "$label" "$detail"
     return 0


### PR DESCRIPTION
## 対応 Issue AC

- [x] AC1: `mise exec -- bash scripts/run-tests.sh` が exit 0 で終わり、bats スイートに `not ok` がない。
- [x] AC2: 09b・40a・40b・40c が `差 N 件` の文字列一致を判定に用いない。
- [x] AC3: `report` の集計本文の表示文言だけの変異では面⑪のみが赤になり、09b・40a・40b・40c は赤にならない。
- [x] AC4: `report` が期待帰結ファイルを読めない変異では09b・40a・40b・40c が赤になる。
- [x] AC5: 09b・40a・40b・40c のラベル文が、各サイトの実際の検査対象と一致する。

## 変更内容

- 09b・40a・40b・40c の `report` 検査を固定の差件数文言から正常経路との出力 baseline 比較へ変更。
- 本体スクリプト、fixture、面⑪は変更なし。

## 検証結果

- `mise exec -- bash scripts/run-tests.sh`: 80 tests, 0 failures、`validate-skills` 成功。
- 表示文言変異: 面⑪のみ失敗、09b・40a・40b・40c は成功。
- 期待帰結読込変異: 09b・40a・40b・40c が失敗。
- Task 1/2 の個別レビューおよびブランチ全体レビュー: APPROVED。

## セルフレビュー実施済み

レビュー: 1周実施、ブロッカー0件を修正済み

### 修正した指摘

なし。

### 改善提案（未対応）

なし。

Closes #710
