### PR TITLE
ci: run test suite in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up mise
         uses: jdx/mise-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          install: false
+
+      - name: Trust repository configuration
+        run: mise trust
+
+      - name: Install test tools
+        run: mise install
+
+      - name: Run test suite
+        run: bash scripts/run-tests.sh


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow for pull requests and pushes to `main`.
- Set up mise, install the pinned bats tool, and run `scripts/run-tests.sh`.

## Issue

Closes #712

## Verification

- `bash scripts/run-tests.sh` — 80 bats tests passed; `validate-skills` passed.
- Ruleset changes are intentionally deferred.
