### PR TITLE
test(adr): remove unsupported surface check

### DIFF
--- a/docs/development/test-execution.md
+++ b/docs/development/test-execution.md
@@ -180,19 +180,19 @@ FAILED: 1/2 suites (6s) -- bats
 
 | 移行前のランナー | 緑経路の `[PASS]` ラベル数 | 移行後のファイル | ケース数 |
 |---|---|---|---|
-| `test-lint-adr.sh` | 137 | `lint-adr-index.bats` / `lint-adr-layers.bats` / `lint-adr-xref.bats` / `lint-adr-surface.bats` / `lint-adr-stem.bats` | 3 / 17 / 8 / 5 / 9 = 42 |
+| `test-lint-adr.sh` | 137 | `lint-adr-index.bats` / `lint-adr-layers.bats` / `lint-adr-xref.bats` / `lint-adr-surface.bats` / `lint-adr-stem.bats` | 3 / 17 / 8 / 4 / 9 = 41 |
 | `test-adr-scoping-cases.sh` | 75 | `adr-scoping-cases-basic.bats` / `adr-scoping-cases-edge.bats` | 16 / 8 = 24 |
 | `test-lint-domain-doc.sh` | 5 | `lint-domain-doc.bats` | 3 |
 | `test-next-adr-id.sh` | 14 | `next-adr-id.bats` | 7 |
 | ローカルプラグイン runner | — | `local-plugin-runners.bats` | 4 |
-| 合計 | 231 | 10ファイル | **80** |
+| 合計 | 231 | 10ファイル | **79** |
 
 **ケース数はアサーション数ではない。** 1ケースは検査の面に対応し、その面に属する検査項目（旧ランナーの `[PASS]` ラベル）を内側に束ねている。移行の完了時点では、旧ラベル231件はすべて `.bats` 本文へ文字列として残してあり、`grep -F` で1件ずつ突き合わせて欠落0件を確認した。その後 2026-08-07 のパーク欄廃止（#563）で `lint-adr-xref.bats` のラベルが8種変化しており、以降は欠落0件が成立しない。**移行に伴う喪失と、廃止に伴う意図的な削除・言い換えを混同しないこと。** 内訳は次のとおり。
 
-- **削除4件**: `(AC6/AC7): 保留した決定が非存在slugを指すと dangling 参照違反` 系3件（exit 1／`dangling 参照違反` を含む／`ADR-202612121021-01-park-missing` を含む）と、`(park link dedup): リンク形式 park dangling は1回のみ報告（count=1）`
+- **削除6件**: `(AC6/AC7): 保留した決定が非存在slugを指すと dangling 参照違反` 系3件（exit 1／`dangling 参照違反` を含む／`ADR-202612121021-01-park-missing` を含む）、`(park link dedup): リンク形式 park dangling は1回のみ報告（count=1）`、および `lint-adr-surface.bats` 面③の `3段構え編集機構の対応表が edit-decision.md に存在する` と `decision tree（些末/非core/core 判定フロー）が edit-decision.md に存在する`
 - **言い換え4件**: `(AC2/AC7-誤検出回避)` 系3件は park の記述を落として `(AC2-誤検出回避)` へ。`(AC5): ヘッダにレイヤ4（Related/park 参照の生存性・実在性）仕様が成文化されている` は `（Related 参照の生存性・実在性）` へ
 
-80 の内訳は **面 71 ＋ 前提不成立 9** である。旧ラベルを持たない新規ケースは次の **16件** に限る。
+79 の内訳は **面 70 ＋ 前提不成立 9** である。旧ラベルを持たない新規ケースは次の **16件** に限る。
 
 - **前提不成立ケース 9件**（`.bats` ファイル1つにつき1件）— fixture corpus・被テスト検査器の不在を、ファイル全体の潰れではなく専用ケースの失敗として報告するためのもの。bats は `setup_file` が失敗するとそのファイルの全ケースを1件へ潰し、報告総数が失敗の有無で変動する。これを避けるため、共有 `setup_file` は判定を一切せず常に `return 0` で終わり、前提の判定は専用ケースが行う。
 - **`lint-adr-surface.bats` の面①（期待リストのファイル存在）と面②（参照ファイルの被覆）の 2件** — 旧 `run_ac5_edit_mechanism` はこの2検査について失敗時にしか総数を加算せず、緑経路では `[PASS]` を1件も出さなかった。集約報告化に伴い緑経路でも報告される独立ケースになるため、旧ラベルを持たない新規ケースとして扱う。前提不成立ケースではない。

--- a/scripts/tests/lint-adr-surface.bats
+++ b/scripts/tests/lint-adr-surface.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # manage-adr スキル面に対する編集機構の面検査。
 #
-# 新スキーマの編集機構（decision tree・3段構え対応表）の文書化と旧記述の除去を検査する。
+# 新スキーマの編集機構に関する旧記述の除去を検査する。
 # 運用ルールの正本は docs/adr/README.md ではなく manage-adr スキル側にあるため、存在検査の
 # 対象を移設先（edit-decision.md）へ張り替えてある。除去検査は、旧記述が再混入しうる面＝
 # manage-adr のスキル面（正本の在処）に対して行う。host 固有の docs/adr/README.md は
@@ -92,20 +92,6 @@ setup_file() {
                 ;;
         esac
     done
-
-    collect_finish
-}
-
-@test "面③: edit-decision.md の内容" {
-    collect_init
-
-    local edit_content
-    edit_content=$(cat "$EDIT_DECISION" 2>/dev/null || true)
-
-    collect_contains "$edit_content" "3段構え" \
-        "AC5: 3段構え編集機構の対応表が edit-decision.md に存在する"
-    collect_contains "$edit_content" "些末" \
-        "AC5: decision tree（些末/非core/core 判定フロー）が edit-decision.md に存在する"
 
     collect_finish
 }


### PR DESCRIPTION
## Summary
- lint-adr-surface の面③（edit-decision.md の内容検査）を削除
- test-execution.md の移行台帳を 80→79 ケース、面 71→70 に更新
- 廃止した旧 PASS 2件を削除内訳へ記録

## Verification
- mise exec -- bats scripts/tests/lint-adr-surface.bats
- mise exec -- bash scripts/run-tests.sh

Closes #723