### PR TITLE
test: cover judgment contract acceptance conditions

### DIFF
--- a/docs/development/adr-scoping-cases/2026-08-11-derivation-examples.md
+++ b/docs/development/adr-scoping-cases/2026-08-11-derivation-examples.md
@@ -15,3 +15,41 @@ $ bash plugins/adr/scripts/adr-scoping-cases.sh derive scripts/fixtures/adr-scop
 ```
 
 項目ごとの点数・合計・行き先は JSON に保存されず、実測事実と設定ファイルから都度導出される。
+
+## 点数を模したフィールドを足しても出力が変化しない
+
+点数・合計・行き先を入力へ保存しても、`derive` はそれらを参照せず、実測事実と閾値設定から算出する。次のコマンドで一時ファイルを作り、点数を模したフィールドを追加した入力を渡す。
+
+```text
+$ extra_input="$(mktemp -t adr-scoping-case-extra.XXXXXX.json)"
+$ jq '. + {"点数_合計": 99, "score": 99}' scripts/fixtures/adr-scoping-cases/returns/CASE-A1-1.json > "$extra_input"
+$ bash plugins/adr/scripts/adr-scoping-cases.sh derive "$extra_input" --thresholds plugins/adr/skills/manage-adr/references/adr-scoring-thresholds.json --doc-commit 0000000
+項目1: 1
+項目2: 0
+項目3: 0
+項目4: 1
+合計: 2
+行き先: 共有規約文書
+$ rm -f "$extra_input"
+```
+
+無改変時の出力と同一であり、点数を模したフィールドは算出へ影響しない。これは契約仕様の「直列化形式」が点数・合計・行き先を保持しないと定めていることにも対応する。
+
+## 実測事実フィールドを改変すると出力が変化する
+
+項目1の追跡下ファイルを閾値の反対側へ変更した入力では、項目1の点数と合計が変化する。
+
+```text
+$ altered_input="$(mktemp -t adr-scoping-case-altered.XXXXXX.json)"
+$ jq '."項目1_追跡下ファイル" = ["a", "b"] | ."項目1_追跡下ファイル数" = 2' scripts/fixtures/adr-scoping-cases/returns/CASE-A1-1.json > "$altered_input"
+$ bash plugins/adr/scripts/adr-scoping-cases.sh derive "$altered_input" --thresholds plugins/adr/skills/manage-adr/references/adr-scoring-thresholds.json --doc-commit 0000000
+項目1: 0
+項目2: 0
+項目3: 0
+項目4: 1
+合計: 1
+行き先: 共有規約文書
+$ rm -f "$altered_input"
+```
+
+無改変時から項目1が `1` から `0` へ、合計が `2` から `1` へ変化している。実測事実を改変した場合は、点数を模したフィールドの追加とは異なり算出結果へ反映される。

--- a/scripts/tests/adr-scoping-cases-basic.bats
+++ b/scripts/tests/adr-scoping-cases-basic.bats
@@ -846,7 +846,7 @@ check_unreadable_case_dir() {
 @test "面㉑: prompt 出力が契約の判定器フィールドと返却雛形を含む" {
     local contract="$REPO_ROOT/plugins/adr/skills/manage-adr/references/adr-judgment-contract.md"
     local cases="$REPO_ROOT/docs/development/adr-scoping-cases"
-    local prompt_path="" prompt_body="" prompt_rc fence_count
+    local prompt_path="" prompt_body="" return_body="" prompt_rc fence_count
     local -a fields=() keys=()
 
     collect_init
@@ -878,19 +878,34 @@ check_unreadable_case_dir() {
             "exit=$prompt_rc / path=$prompt_path"
     fi
 
+    # 返却形式の見出し直後にあるフェンス区間だけを切り出す。prompt 全体を対象にすると、
+    # 題材文や別のコードブロックにキーが現れたとき、返却雛形の欠落を見逃すためである。
+    return_body="$(printf '%s\n' "$prompt_body" | awk '
+        /^## 返却形式（厳守）$/ { in_return=1; next }
+        in_return && /^```/ {
+            if (!opened) { opened=1; next }
+            exit
+        }
+        in_return && opened { print }
+    ' )"
+
     # 素の部分一致では短いフィールド名が長いフィールド名の接頭辞に隠れるため、
-    # JSON キー形（"名前":）で全件を一括照合する。
+    # JSON キー形（"名前":）で返却雛形の区間内にある全件を一括照合する。
     local field
     for field in "${fields[@]}"; do
         keys+=("\"${field}\":")
     done
-    collect_out "$prompt_body" \
+    collect_out "$return_body" \
         "49. prompt 出力に契約の判定器記入フィールド27件がJSONキー形で全て現れる" \
         "${keys[@]}"
 
     # 実データ雛形の返却形式は言語タグ無しの素の ``` で囲まれる。```json に固定しない。
-    fence_count="$(printf '%s\n' "$prompt_body" | awk 'index($0, "```") { count++ } END { print count + 0 }')"
-    if [ "$fence_count" -ge 2 ]; then
+    fence_count="$(printf '%s\n' "$prompt_body" | awk '
+        /^## 返却形式（厳守）$/ { in_return=1; next }
+        in_return && /^```/ { count++ }
+        END { print count + 0 }
+    ' )"
+    if [ "$fence_count" -eq 2 ] && [ -n "$return_body" ]; then
         collect_ok "50. prompt 出力に返却直列化形式を囲むフェンスが対で現れる"
     else
         collect_fail "50. prompt 出力に返却直列化形式を囲むフェンスが対で現れる" \

--- a/scripts/tests/adr-scoping-cases-basic.bats
+++ b/scripts/tests/adr-scoping-cases-basic.bats
@@ -839,3 +839,64 @@ check_unreadable_case_dir() {
     run grep -F "adr-scoring-thresholds.json" "$skill"
     [ "$status" -eq 0 ]
 }
+
+# fixture の prompt-template.md は契約フィールドを JSON キー形で持たないため、ここでは
+# 配布・運用される実データを対象にする。実データを通る常設テストが対象を取り違えないよう、
+# 契約文書と題材集合のパスを変数にしている。変異確認ではこの2変数を複製先へ差し替える。
+@test "面㉑: prompt 出力が契約の判定器フィールドと返却雛形を含む" {
+    local contract="$REPO_ROOT/plugins/adr/skills/manage-adr/references/adr-judgment-contract.md"
+    local cases="$REPO_ROOT/docs/development/adr-scoping-cases"
+    local prompt_path="" prompt_body="" prompt_rc fence_count
+    local -a fields=() keys=()
+
+    collect_init
+
+    # 現行契約で判定器が記入するフィールド数は27件。契約表の形式が変わって抽出が
+    # 空振りした場合に、照合ゼロのまま緑へ縮退させないため下限を先に検査する。
+    mapfile -t fields < <(awk -F'|' '
+        /^[|].*[|]$/ && $2 !~ /フィールド名/ && $5 ~ /判定器/ {
+            field=$2
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", field)
+            print field
+        }
+    ' "$contract")
+    if [ "${#fields[@]}" -ge 27 ]; then
+        collect_ok "47. 契約仕様から判定器記入フィールドを27件以上抽出する"
+    else
+        collect_fail "47. 契約仕様から判定器記入フィールドを27件以上抽出する" \
+            "抽出件数が不足: ${#fields[@]}"
+    fi
+
+    sc_stdout prompt "$DOC" CASE-01 "$cases"
+    prompt_path="$output"
+    prompt_rc="$status"
+    if [ "$prompt_rc" -eq 0 ] && [ -f "$prompt_path" ]; then
+        collect_ok "48. 実データ CASE-01 の prompt が一時ファイルを返す"
+        prompt_body="$(cat "$prompt_path")"
+    else
+        collect_fail "48. 実データ CASE-01 の prompt が一時ファイルを返す" \
+            "exit=$prompt_rc / path=$prompt_path"
+    fi
+
+    # 素の部分一致では短いフィールド名が長いフィールド名の接頭辞に隠れるため、
+    # JSON キー形（"名前":）で全件を一括照合する。
+    local field
+    for field in "${fields[@]}"; do
+        keys+=("\"${field}\":")
+    done
+    collect_out "$prompt_body" \
+        "49. prompt 出力に契約の判定器記入フィールド27件がJSONキー形で全て現れる" \
+        "${keys[@]}"
+
+    # 実データ雛形の返却形式は言語タグ無しの素の ``` で囲まれる。```json に固定しない。
+    fence_count="$(printf '%s\n' "$prompt_body" | awk 'index($0, "```") { count++ } END { print count + 0 }')"
+    if [ "$fence_count" -ge 2 ]; then
+        collect_ok "50. prompt 出力に返却直列化形式を囲むフェンスが対で現れる"
+    else
+        collect_fail "50. prompt 出力に返却直列化形式を囲むフェンスが対で現れる" \
+            "フェンス行数が不足: $fence_count"
+    fi
+
+    [ -n "$prompt_path" ] && [ -f "$prompt_path" ] && rm -f "$prompt_path"
+    collect_finish
+}


### PR DESCRIPTION
## 概要
Issue #714 の未充足受入条件 AC3・AC7 を解消します。

## 対応 Issue AC
- AC3: derive の改変入力2例と実測出力を実行例文書へ記録
- AC7: prompt 出力と契約仕様の判定器フィールド27件・返却雛形を検査する面㉑を追加
- AC9: 全スイートで回帰確認

## セルフレビュー実施済み
- 変異確認: 雛形のフィールド欠落、契約表の抽出空振りがともに失敗することを確認
- 全スイート: 86 tests, 0 failures
- validate-skills: 成功

## 変更ファイル
- docs/development/adr-scoping-cases/2026-08-11-derivation-examples.md
- scripts/tests/adr-scoping-cases-basic.bats