### PR TITLE
feat(adr): add cross-host portability wave 1 contract

### DIFF
--- a/docs/development/plugin-path-reference-ledger.md
+++ b/docs/development/plugin-path-reference-ledger.md
@@ -60,3 +60,6 @@
 | scripts/tests/lint-adr-stem.bats | 2 | plugins/adr | adr | fixture | wave-0 | current |
 | scripts/tests/lint-adr-xref.bats | 2 | plugins/adr | adr | fixture | wave-0 | current |
 | scripts/tests/next-adr-id.bats | 2 | plugins/adr | adr | fixture | wave-0 | current |
+| scripts/tests/adr-portability.bats | 18 | plugins/adr | adr | fixture | wave-1 | current |
+| scripts/tests/adr-portability.bats | 22 | plugins/adr | adr | fixture | wave-1 | current |
+| scripts/tests/adr-portability.bats | 27 | plugins/adr | adr | fixture | wave-1 | current |

--- a/docs/references/cross-host-compatibility.json
+++ b/docs/references/cross-host-compatibility.json
@@ -12,5 +12,18 @@
     "codexLevel": "surface-specific",
     "fixtures": ["growth-codex-surface"],
     "residualRisk": "growthはClaudeのsession jsonl/local store依存のため、Codex適合を行わない"
+  },
+  {
+    "feature": "ADR explicit validation contract",
+    "claudeLevel": "portable",
+    "codexLevel": "portable",
+    "fixtures": ["adr-wave1"]
+  },
+  {
+    "feature": "ADR commit hook enforcement",
+    "claudeLevel": "portable",
+    "codexLevel": "degraded",
+    "fixtures": ["adr-wave1"],
+    "residualRisk": "Codexには現時点でClaude CodeのPreToolUse相当のplugin単位commit hookがなく、明示lint外のcommitはdriftを防げない"
   }
 ]

--- a/docs/references/cross-host-permission-ledger.json
+++ b/docs/references/cross-host-permission-ledger.json
@@ -4,6 +4,26 @@
     "requiredOperation": "配布物内の参照を読む",
     "witness": "read-plugin-reference",
     "narrowerAlternative": "なし。個別ファイルは入力で変動する",
-    "verdict": "necessary"
+    "verdict": "necessary",
+    "plugin": "adr",
+    "host": "claude"
+  },
+  {
+    "permission": "PreToolUse hook: Bash(git commit:*)",
+    "requiredOperation": "git commit前にADR drift-lintを実行して違反時にcommitをブロックする",
+    "witness": "adr-wave1 / Claude Code hook",
+    "narrowerAlternative": "なし。git commitコマンドだけを対象にする現行条件が最小",
+    "verdict": "necessary",
+    "plugin": "adr",
+    "host": "claude"
+  },
+  {
+    "permission": "Codex sandbox/approval policy",
+    "requiredOperation": "ADR操作でファイルを書き込み、同梱lint/index/idスクリプトを実行する",
+    "witness": "adr-wave1 / explicit ADR validation",
+    "narrowerAlternative": "plugin単位のhook制約は現行Codexにないため代替不可",
+    "verdict": "degraded",
+    "plugin": "adr",
+    "host": "codex"
   }
 ]

--- a/docs/superpowers/specs/2026-08-11-cross-host-plugin-architecture-design.md
+++ b/docs/superpowers/specs/2026-08-11-cross-host-plugin-architecture-design.md
@@ -311,6 +311,8 @@ Issueの作成、準備判定、計画、実装、PRまでを一つの開発ラ�
 
 このWaveでCodex hookの有無と保証範囲を調査する。hookを使えない場合は、明示lintを必須契約とする `degraded` としてfixture、代替検証、残余リスクを記録する。
 
+Wave 1は案A（共通のADR成果契約と既存スクリプトを維持）で実装し、案Bのhost adapterは将来の移行先として残す。Codexがplugin単位のhook/policy callbackと、lintの非0結果をcommitへ返してブロックできる保証を提供した時点を移行トリガーとする。それまではホスト別本文やスクリプトを複製せず、`adr-wave1` fixture、compatibility matrix、permission ledger、ADR READMEにこの判断と残余リスクを記録する。
+
 ### Wave 2: Writing
 
 既存のwriting設計とIssue #683、#684、#685を入力に、`write-doc`、`doc-writer`、`doc-reviewer` を両ホストへ適合させる。新しい基盤スキル名や別レビュー構造を導入しない。

--- a/plugins/adr/.claude-plugin/plugin.json
+++ b/plugins/adr/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "adr",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Claude Code向けのADR（アーキテクチャ決定記録）運用プラグイン。front-matterスキーマ検証・有効性index生成・drift-lint（commit前ゲート）と、ライフサイクル操作スキル manage-adr を提供する。検査対象の ADR ディレクトリは lint-adr.sh / gen-adr-index.sh の第1引数（既定 docs/adr）で指定する。"
 }

--- a/plugins/adr/.codex-plugin/plugin.json
+++ b/plugins/adr/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adr",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "ADRのライフサイクル管理と検証を支援するCodexプラグイン。",
   "author": {
     "name": "Kuchita El"

--- a/plugins/adr/README.md
+++ b/plugins/adr/README.md
@@ -1,6 +1,6 @@
 # adr プラグイン
 
-ADR（アーキテクチャ決定記録）の運用機構を配布する Claude Code プラグイン。どの GitHub リポジトリにも導入でき、ADR の drift-lint・有効性 index 生成・ライフサイクル操作を提供する。
+ADR（アーキテクチャ決定記録）の運用機構を配布する Claude Code / Codex プラグイン。どの GitHub リポジトリにも導入でき、ADR の drift-lint・有効性 index 生成・ライフサイクル操作を提供する。
 
 ## 提供物
 
@@ -10,6 +10,16 @@ ADR（アーキテクチャ決定記録）の運用機構を配布する Claude 
 - **固定題材集合の実行支援（`scripts/adr-scoping-cases.sh`）**: 判定手続きを定めた文書を被テスト対象とし、固定した題材を通して帰結の差を見るための検査器。`prompt` / `validate` / `report` に加え、保存済みJSONの実測事実から `derive` が点数を算出し、`crosscheck` が台帳の点数列と一致検査する。題材集合ディレクトリと対象文書パスは引数で受け、既定値を持たない（理由はスクリプト冒頭のコメントに置く）。**本スクリプトは manage-adr スキルからも commit ゲートからも呼ばれず、判定手続き文書を改訂する担い手が手で起動する。** 題材集合そのものは各リポジトリが自前で用意する。
 - **commit 前ゲート（`hooks/`）**: `git commit` 時に PreToolUse フックとして drift-lint を実行し、違反があれば commit をブロックする（exit 2）。対象リポジトリに ADR ディレクトリが存在しない場合は何もしない（no-op）。
 - **manage-adr スキル（`skills/manage-adr/`）**: ADR の起票・承認・上書き・廃止・却下・編集・分割を対話的に行うライフサイクル操作スキル。
+
+## ホスト差分
+
+両ホストの成果契約は、明示的に `lint-adr.sh`、`gen-adr-index.sh`、
+`next-adr-id.sh` を実行して結果を確認することです。Claude Codeでは追加で
+PreToolUseのcommitゲートを利用できます。Codexには現時点で同等のplugin単位
+commit hookがないため、明示lintを必須とする `degraded` 互換です。
+
+Codexがplugin単位のhook/policy callbackとブロック結果を提供した時点を、
+host adapterへ移行するトリガーとします。移行まではホスト別のworkflowを複製しません。
 
 同梱スクリプトのテストランナーと fixture は本配布物に含めない。配布物が持つのは検査器のみであり、検査用データの同梱と、スクリプトが自環境で動くことの確認は本配布物の責務ではない。
 

--- a/plugins/adr/skills/manage-adr/SKILL.md
+++ b/plugins/adr/skills/manage-adr/SKILL.md
@@ -17,6 +17,8 @@ allowed-tools:
 
 ADR の各遷移（起票・承認・上書き・廃止・却下）と既存 ADR の編集で、front-matter（`status`/`validity`/`superseded-by`）と `## 関連ADR` の相互参照を正しく書き込む。手順の実体は本スキルが持ち、手作業で組み立てずスキル経由で一貫した状態遷移を実行し、各操作の締めに drift-lint で自己検証する。
 
+Claude Codeではcommit前PreToolUse hookが補助的に同じlintを実行する。Codexにはこのplugin単位hookがないため、ホストにかかわらず各操作後の明示lintを必須とする。Codex側のhook/policy callbackが利用可能になった場合だけ、重複workflowを作らずhost adapterへ移行する。
+
 状態値は日本語ユビキタス言語（`提案中`/`承認済み`/`却下`/`有効`/`上書き済み`/`廃止済み`）、キーは英語。値の説明・トレーリングコメントを front-matter 内に書かない（lint パーサが行全体を値として取り込むため）。
 
 ## 引数

--- a/scripts/fixtures/skill-portability/adr-wave1/README.md
+++ b/scripts/fixtures/skill-portability/adr-wave1/README.md
@@ -1,0 +1,16 @@
+# ADR Wave 1 portability fixture
+
+This fixture records the ADR plugin's host-neutral result contract and the
+host-specific execution paths used to produce it.
+
+- **explicit ADR validation**: both hosts must be able to run the bundled
+  `lint-adr.sh`, `gen-adr-index.sh`, and `next-adr-id.sh` operations and
+  observe their exit status/output.
+- **Claude Code hook**: Claude Code may enforce the same lint at
+  `git commit` through the bundled PreToolUse hook.
+- **Codex: degraded**: Codex has no equivalent per-plugin commit hook in the
+  current contract, so explicit lint is mandatory and commits outside that
+  workflow retain a residual drift risk.
+- **adapter migration trigger**: introduce a host adapter when Codex exposes a
+  supported per-plugin hook/policy callback that can invoke the same lint and
+  return a blocking result. Until then, do not duplicate the ADR workflow.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -78,6 +78,7 @@ MSG
 EXPECTED_BATS=(
     adr-scoping-cases-basic.bats
     adr-scoping-cases-edge.bats
+    adr-portability.bats
     lint-adr-index.bats
     lint-adr-layers.bats
     lint-adr-stem.bats

--- a/scripts/tests/adr-portability.bats
+++ b/scripts/tests/adr-portability.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load 'helpers/common'
+
+@test "ADR Wave 1 fixtureは成果契約とCodex縮退条件を列挙する" {
+    fixture="$REPO_ROOT/scripts/fixtures/skill-portability/adr-wave1/README.md"
+
+    [ -f "$fixture" ]
+    grep -Fq 'explicit ADR validation' "$fixture"
+    grep -Fq 'Claude Code hook' "$fixture"
+    grep -Fq 'Codex: degraded' "$fixture"
+    grep -Fq 'adapter migration trigger' "$fixture"
+}
+
+@test "ADR Wave 1の決定的スクリプトは両ホスト共通の成果を検査できる" {
+    corpus="$REPO_ROOT/scripts/fixtures/lint-adr/valid/01-mixed-validity"
+
+    run bash "$REPO_ROOT/plugins/adr/scripts/lint-adr.sh" "$corpus"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+
+    run bash "$REPO_ROOT/plugins/adr/scripts/gen-adr-index.sh" "$corpus"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'# 有効 ADR インデックス'* ]]
+    [[ "$output" == *'ADR-202601010901-01-sample-decision'* ]]
+
+    run bash "$REPO_ROOT/plugins/adr/scripts/next-adr-id.sh" "$corpus"
+    [ "$status" -eq 0 ]
+    [[ "$output" == ADR-* ]]
+}


### PR DESCRIPTION
## 概要

ADR pluginをCross-host plugin Wave 1の最初の適合例として整理しました。

## 対応 Issue AC

- [x] ADRの両ホスト共通成果契約（lint / index / ID生成）をfixtureで検証
- [x] Claude Codeのcommit hookとCodexのhook非対応をcompatibility matrixへ明記
- [x] permission ledgerへClaude/Codexの権限契約と`degraded`残余リスクを追加
- [x] ADR READMEとmanage-adr skillへホスト差分を記録
- [x] Wave 1 fixtureをrunnerの期待リスト・path reference ledgerへ登録
- [x] 両manifestのversionを`0.2.0`から`0.3.0`へ更新
- [x] 将来host adapterへ移行するトリガーを設計書・README・skill・fixtureへ記録

## 実装内容

- `adr-wave1` portability fixtureを追加
- `adr-portability.bats`で、lintのexit/output、indexの代表内容、ID生成、fixture契約を検証
- Codexは現時点でplugin単位commit hookがないため、明示lint必須の`degraded`とした
- Codexがplugin単位のhook/policy callbackとブロック結果を提供した時点をadapter移行トリガーとした

## セルフレビュー実施済み

- 周回数: 2（初回実装、独立レビュー指摘対応）
- 修正ブロッカー数: 1

### 修正した指摘

| 重大度 | 指摘 | 対応内容 | コミット |
|---|---|---|---|
| Important | ADR fixtureがlint/indexのexit codeだけを検証し、成果物内容を検証していない | lint空出力、index見出し、代表ADR名のassertionを追加 | `a8536e5` |

### 深刻度調整（誤検知格下げ）

なし。

### 改善提案（未対応）

- 将来adapterの移行トリガーは現在、設計書・README・skill・fixtureの文書契約として管理している。Codex側に対象APIが追加された時点で、構造化されたcapability probeへ拡張する。

## 検証結果

`bash scripts/run-tests.sh`:

- 108 tests, 0 failures
- 6 suites passed
- validate-skills / manifests / versions / portability / path-references: all passed

## 残余リスク

Codexでは現時点でClaude CodeのPreToolUse相当のplugin単位commit hookがないため、明示lint外のcommitではdriftを自動阻止できません。これはmatrixとpermission ledgerで`degraded`として明示しています。
