### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Git worktrees placed inside the repo
 .claude/worktrees/
+.worktrees/
 
 # growth プラグインの個人ローカル store（in-repo dogfooding 用。生捕捉はコミットしない。詳細は plugins/growth/references/personal-store-spec.md）
 plugins/growth/.local/

--- a/docs/development/plugin-path-reference-ledger.md
+++ b/docs/development/plugin-path-reference-ledger.md
@@ -4,8 +4,8 @@
 
 | path | line | pluginPath | owner | purpose | migrationWave | expected |
 |---|---:|---|---|---|---|---|
-| .gitignore | 7 | plugins/growth | growth | local store exclusion | wave-0 | current |
 | .gitignore | 8 | plugins/growth | growth | local store exclusion | wave-0 | current |
+| .gitignore | 9 | plugins/growth | growth | local store exclusion | wave-0 | current |
 | CLAUDE.md | 25 | plugins/dev-workflow | dev-workflow | repository architecture | wave-0 | current |
 | CLAUDE.md | 26 | plugins/dev-workflow | dev-workflow | repository architecture | wave-0 | current |
 | CLAUDE.md | 27 | plugins/dev-workflow | dev-workflow | repository architecture | wave-0 | current |


### PR DESCRIPTION
## Summary
- Ignore repository-local `.worktrees/` directories.
- Update the plugin path ledger for the shifted `.gitignore` line.

## Verification
- `bash scripts/run-tests.sh`
- 148 tests, 0 failures
- 6 suites passed