### PR TITLE
fix: exclude growth from Codex distribution

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -17,18 +17,6 @@
       "category": "Developer Tools"
     },
     {
-      "name": "growth",
-      "source": {
-        "source": "local",
-        "path": "./plugins/growth"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "Productivity"
-    },
-    {
       "name": "adr",
       "source": {
         "source": "local",

--- a/docs/development/plugin-path-reference-ledger.md
+++ b/docs/development/plugin-path-reference-ledger.md
@@ -1,17 +1,16 @@
 # plugin path reference ledger
 
-`growth` は既存runner導入対象として保持するが、Claudeのsession jsonl/local store依存のため、Codexでは恒久的に `surface-specific` として扱う。Codex adapterを追加する場合のみcompatibility matrixと本台帳を更新し、適合判定対象へ戻す。
+`growth` はClaudeのsession jsonl/local store依存のため、Codex marketplaceとrunnerの導入対象から除外し、恒久的に `surface-specific` として扱う。Codex adapterを追加する場合のみcompatibility matrixと本台帳を更新し、適合判定対象へ戻す。
 
 This ledger is regenerated when tracked source/config/docs add or move a `plugins/<name>` reference.
 
 | path | line | pluginPath | owner | purpose | migrationWave | expected |
 |---|---:|---|---|---|---|---|
 | .agents/plugins/marketplace.json | 11 | plugins/dev-workflow | migration | reference | wave-5 | current |
-| .agents/plugins/marketplace.json | 23 | plugins/growth | migration | reference | wave-5 | current |
-| .agents/plugins/marketplace.json | 35 | plugins/adr | migration | reference | wave-5 | current |
-| .agents/plugins/marketplace.json | 47 | plugins/writing | migration | reference | wave-5 | current |
-| .agents/plugins/marketplace.json | 59 | plugins/dependency-insight | migration | reference | wave-5 | current |
-| .agents/plugins/marketplace.json | 71 | plugins/domain-design | migration | reference | wave-5 | current |
+| .agents/plugins/marketplace.json | 23 | plugins/adr | migration | reference | wave-5 | current |
+| .agents/plugins/marketplace.json | 35 | plugins/writing | migration | reference | wave-5 | current |
+| .agents/plugins/marketplace.json | 47 | plugins/dependency-insight | migration | reference | wave-5 | current |
+| .agents/plugins/marketplace.json | 59 | plugins/domain-design | migration | reference | wave-5 | current |
 | .claude-plugin/marketplace.json | 9 | plugins/dev-workflow | migration | reference | wave-5 | current |
 | .claude-plugin/marketplace.json | 13 | plugins/growth | migration | reference | wave-5 | current |
 | .claude-plugin/marketplace.json | 17 | plugins/adr | migration | reference | wave-5 | current |

--- a/docs/references/cross-host-compatibility.json
+++ b/docs/references/cross-host-compatibility.json
@@ -8,6 +8,7 @@
   },
   {
     "feature": "growth plugin portability",
+    "plugin": "growth",
     "claudeLevel": "portable",
     "codexLevel": "surface-specific",
     "fixtures": ["growth-codex-surface"],

--- a/docs/references/cross-host-plugin-conformance.md
+++ b/docs/references/cross-host-plugin-conformance.md
@@ -11,12 +11,15 @@ matrixはJSON配列として保持し、各行は次の字段を持つ。`residu
 | 字段 | 型 | 値域・意味 |
 |---|---|---|
 | `feature` | string | 検査対象の能力名。空文字不可 |
+| `plugin` | string | 任意。片host固有の配布差分を宣言する場合は対象plugin名を指定する |
 | `claudeLevel` | enum | `portable` / `adapted` / `degraded` / `surface-specific` |
 | `codexLevel` | enum | 同上 |
 | `fixtures` | array[string] | 少なくとも1件の再現fixture |
 | `residualRisk` | string | `degraded` または `surface-specific` の場合は必須。それ以外では省略可。存在時は空文字不可 |
 
 `portable` は同じ契約で利用できること、`adapted` はhost adapterを介して同じ成果を得ること、`degraded` は自動保証を縮退させ残余リスクを明記すること、`surface-specific` は片host固有であることを示す。
+
+`plugin` を持つ行で `codexLevel` が `surface-specific` の場合、検査器はそのpluginがCodex marketplaceに存在しないことを許容する。`claudeLevel` が `surface-specific` の場合はClaude marketplace側の欠落を許容する。片host固有の例外はplugin名とhost側のlevelをmatrixへ宣言し、検査器へplugin名を直接ハードコードしない。
 
 ## Permission ledger
 

--- a/scripts/tests/local-plugin-runners.bats
+++ b/scripts/tests/local-plugin-runners.bats
@@ -59,6 +59,7 @@ setup() {
     grep -Fx -- 'codex|plugin|add|superpowers@openai-curated' "$CALLS"
     grep -Fx -- 'codex|plugin|add|domain-design@claude-shared-skills' "$CALLS"
     grep -Fx -- 'codex|plugin|add|dependency-insight@claude-shared-skills' "$CALLS"
+    ! grep -Fx -- 'codex|plugin|add|growth@claude-shared-skills' "$CALLS"
     grep -Fx -- 'codex|--model|gpt-5.6|--search' "$CALLS"
 }
 

--- a/scripts/tests/plugin-manifests.bats
+++ b/scripts/tests/plugin-manifests.bats
@@ -13,6 +13,37 @@ setup() { SUT="$REPO_ROOT/scripts/validate-plugin-manifests.sh"; }
   [ "$status" -eq 1 ]
   [[ "$output" == *"Codex marketplaceに無い: example"* ]]
 }
+@test "surface-specific宣言済みの片側plugin欠落を許容する" {
+  fixture="$BATS_FILE_TMPDIR/surface-specific"
+  cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
+  mkdir -p "$fixture/docs/references"
+  jq '.plugins += [{"name":"growth","source":"./plugins"}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
+  mv "$fixture/.claude-plugin/marketplace.json.next" "$fixture/.claude-plugin/marketplace.json"
+  printf '%s\n' '[{"feature":"growth","plugin":"growth","claudeLevel":"portable","codexLevel":"surface-specific","fixtures":["example"],"residualRisk":"Codexでは提供しない"}]' >"$fixture/docs/references/cross-host-compatibility.json"
+  run bash "$SUT" "$fixture"
+  [ "$status" -eq 0 ]
+}
+@test "surface-specific未宣言の片側plugin欠落を報告する" {
+  fixture="$BATS_FILE_TMPDIR/undeclared-surface-specific"
+  cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
+  mkdir -p "$fixture/docs/references"
+  jq '.plugins += [{"name":"growth","source":"./plugins"}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
+  mv "$fixture/.claude-plugin/marketplace.json.next" "$fixture/.claude-plugin/marketplace.json"
+  printf '%s\n' '[{"feature":"example","plugin":"example","claudeLevel":"portable","codexLevel":"portable","fixtures":["example"]}]' >"$fixture/docs/references/cross-host-compatibility.json"
+  run bash "$SUT" "$fixture"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Codex marketplaceに無い: growth"* ]]
+}
+@test "surface-specific宣言済みのClaude側plugin欠落を許容する" {
+  fixture="$BATS_FILE_TMPDIR/surface-specific-claude"
+  cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
+  mkdir -p "$fixture/docs/references"
+  jq '.plugins += [{"name":"codex-only","source":{"path":"./plugins"}}]' "$fixture/.agents/plugins/marketplace.json" >"$fixture/.agents/plugins/marketplace.json.next"
+  mv "$fixture/.agents/plugins/marketplace.json.next" "$fixture/.agents/plugins/marketplace.json"
+  printf '%s\n' '[{"feature":"codex-only","plugin":"codex-only","claudeLevel":"surface-specific","codexLevel":"portable","fixtures":["example"],"residualRisk":"Claudeでは提供しない"}]' >"$fixture/docs/references/cross-host-compatibility.json"
+  run bash "$SUT" "$fixture"
+  [ "$status" -eq 0 ]
+}
 @test "manifest version差を報告する" {
   run bash "$SUT" "$FIXTURES_DIR/plugin-manifests/version-mismatch"
   [ "$status" -eq 1 ]

--- a/scripts/tests/plugin-manifests.bats
+++ b/scripts/tests/plugin-manifests.bats
@@ -30,6 +30,18 @@ setup() { SUT="$REPO_ROOT/scripts/validate-plugin-manifests.sh"; }
   run bash "$SUT" "$fixture"
   [ "$status" -eq 0 ]
 }
+@test "surface-specific免除でもClaude側source検査を実行する" {
+  fixture="$BATS_FILE_TMPDIR/surface-specific-claude-checks"
+  cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
+  mkdir -p "$fixture/docs/references"
+  growth_name=growth
+  jq --arg name "$growth_name" --arg source "./plugins/$growth_name" '.plugins += [{"name":$name,"source":$source}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
+  mv "$fixture/.claude-plugin/marketplace.json.next" "$fixture/.claude-plugin/marketplace.json"
+  printf '%s\n' '[{"feature":"growth","plugin":"growth","claudeLevel":"portable","codexLevel":"surface-specific","fixtures":["example"],"residualRisk":"Codexでは提供しない"}]' >"$fixture/docs/references/cross-host-compatibility.json"
+  run bash "$SUT" "$fixture"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Claude source pathが無い: growth"* ]]
+}
 @test "surface-specific未宣言の片側plugin欠落を報告する" {
   fixture="$BATS_FILE_TMPDIR/undeclared-surface-specific"
   cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"

--- a/scripts/tests/plugin-manifests.bats
+++ b/scripts/tests/plugin-manifests.bats
@@ -17,7 +17,14 @@ setup() { SUT="$REPO_ROOT/scripts/validate-plugin-manifests.sh"; }
   fixture="$BATS_FILE_TMPDIR/surface-specific"
   cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
   mkdir -p "$fixture/docs/references"
-  jq '.plugins += [{"name":"growth","source":"./plugins"}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
+  growth_name=growth
+  growth_path="$fixture/plugins/$growth_name"
+  mkdir -p "$growth_path/.claude-plugin" "$growth_path/.codex-plugin" "$growth_path/skills/growth-skill"
+  printf '%s\n' '{"name":"growth","version":"0.1.0"}' >"$growth_path/.claude-plugin/plugin.json"
+  printf '%s\n' '{"name":"growth","version":"0.1.0","skills":"./skills/"}' >"$growth_path/.codex-plugin/plugin.json"
+  printf '%s\n' '# growth' >"$growth_path/README.md"
+  touch "$growth_path/skills/growth-skill/SKILL.md"
+  jq --arg name "$growth_name" --arg source "./plugins/$growth_name" '.plugins += [{"name":$name,"source":$source}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
   mv "$fixture/.claude-plugin/marketplace.json.next" "$fixture/.claude-plugin/marketplace.json"
   printf '%s\n' '[{"feature":"growth","plugin":"growth","claudeLevel":"portable","codexLevel":"surface-specific","fixtures":["example"],"residualRisk":"Codexでは提供しない"}]' >"$fixture/docs/references/cross-host-compatibility.json"
   run bash "$SUT" "$fixture"
@@ -27,7 +34,7 @@ setup() { SUT="$REPO_ROOT/scripts/validate-plugin-manifests.sh"; }
   fixture="$BATS_FILE_TMPDIR/undeclared-surface-specific"
   cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
   mkdir -p "$fixture/docs/references"
-  jq '.plugins += [{"name":"growth","source":"./plugins"}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
+  jq '.plugins += [{"name":"growth","source":"./plugins/example"}]' "$fixture/.claude-plugin/marketplace.json" >"$fixture/.claude-plugin/marketplace.json.next"
   mv "$fixture/.claude-plugin/marketplace.json.next" "$fixture/.claude-plugin/marketplace.json"
   printf '%s\n' '[{"feature":"example","plugin":"example","claudeLevel":"portable","codexLevel":"portable","fixtures":["example"]}]' >"$fixture/docs/references/cross-host-compatibility.json"
   run bash "$SUT" "$fixture"
@@ -43,6 +50,17 @@ setup() { SUT="$REPO_ROOT/scripts/validate-plugin-manifests.sh"; }
   printf '%s\n' '[{"feature":"codex-only","plugin":"codex-only","claudeLevel":"surface-specific","codexLevel":"portable","fixtures":["example"],"residualRisk":"Claudeでは提供しない"}]' >"$fixture/docs/references/cross-host-compatibility.json"
   run bash "$SUT" "$fixture"
   [ "$status" -eq 0 ]
+}
+@test "surface-specific未宣言のClaude側plugin欠落を報告する" {
+  fixture="$BATS_FILE_TMPDIR/undeclared-surface-specific-claude"
+  cp -R "$FIXTURES_DIR/plugin-manifests/valid" "$fixture"
+  mkdir -p "$fixture/docs/references"
+  jq '.plugins += [{"name":"codex-only","source":{"path":"./plugins"}}]' "$fixture/.agents/plugins/marketplace.json" >"$fixture/.agents/plugins/marketplace.json.next"
+  mv "$fixture/.agents/plugins/marketplace.json.next" "$fixture/.agents/plugins/marketplace.json"
+  printf '%s\n' '[{"feature":"example","plugin":"example","claudeLevel":"portable","codexLevel":"portable","fixtures":["example"]}]' >"$fixture/docs/references/cross-host-compatibility.json"
+  run bash "$SUT" "$fixture"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Claude marketplaceに無い: codex-only"* ]]
 }
 @test "manifest version差を報告する" {
   run bash "$SUT" "$FIXTURES_DIR/plugin-manifests/version-mismatch"

--- a/scripts/validate-plugin-manifests.sh
+++ b/scripts/validate-plugin-manifests.sh
@@ -53,24 +53,11 @@ for name in "${codex_names[@]}"; do
 done
 
 for name in "${claude_names[@]}"; do
-  if ! printf '%s\n' "${codex_names[@]}" | grep -Fxq "$name"; then
-    declared_surface_specific codex "$name" && continue
-  fi
   claude_path="$root/$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source' "$claude_marketplace")"
-  codex_path="$root/$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source.path' "$codex_marketplace")"
   [ -d "$claude_path" ] || fail "Claude source pathが無い: $name"
-  [ -d "$codex_path" ] || fail "Codex source pathが無い: $name"
   claude_manifest="$claude_path/.claude-plugin/plugin.json"
-  codex_manifest="$codex_path/.codex-plugin/plugin.json"
   [ -f "$claude_manifest" ] || fail "Claude manifestが無い: $name"
-  [ -f "$codex_manifest" ] || fail "Codex manifestが無い: $name"
-  if [ -f "$claude_manifest" ] && [ -f "$codex_manifest" ]; then
-    [ "$(jq -r .name "$claude_manifest")" = "$name" ] || fail "Claude manifest name不一致: $name"
-    [ "$(jq -r .name "$codex_manifest")" = "$name" ] || fail "Codex manifest name不一致: $name"
-    if [ "$(jq -r .version "$claude_manifest")" != "$(jq -r .version "$codex_manifest")" ]; then
-      fail "version不一致: $name"
-    fi
-  fi
+  [ "$(jq -r .name "$claude_manifest" 2>/dev/null)" = "$name" ] || fail "Claude manifest name不一致: $name"
   [ -f "$claude_path/README.md" ] || fail "READMEが無い: $name"
   mapfile -t skills < <(find "$claude_path/skills" -mindepth 2 -maxdepth 2 -name SKILL.md -print 2>/dev/null | sort)
   collect_skill_names() {
@@ -80,15 +67,27 @@ for name in "${claude_names[@]}"; do
       printf '%s\n' "${relative%/SKILL.md}"
     done < <(find "$plugin_path/skills" -mindepth 2 -maxdepth 2 -name SKILL.md -print 2>/dev/null | sort)
   }
-  mapfile -t codex_skill_names < <(collect_skill_names "$codex_path")
   mapfile -t claude_skill_names < <(collect_skill_names "$claude_path")
   for skill in "${claude_skill_names[@]}"; do all_skill_names+=("$skill"); done
-  if [ "$(jq -r '.skills // empty' "$codex_manifest" 2>/dev/null)" = "./skills/" ]; then
-    [ "${#skills[@]}" -gt 0 ] || fail "検査対象skillが0件: $name"
-  fi
-  # Claude/Codex source pathが現状同じでも、marketplaceがhost別に分岐した時点で両集合のdriftを検出する。
-  if [ "$(printf '%s\n' "${claude_skill_names[@]}")" != "$(printf '%s\n' "${codex_skill_names[@]}")" ]; then
-    fail "skill集合不一致: $name"
+  if printf '%s\n' "${codex_names[@]}" | grep -Fxq "$name"; then
+    codex_path="$root/$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source.path' "$codex_marketplace")"
+    [ -d "$codex_path" ] || fail "Codex source pathが無い: $name"
+    codex_manifest="$codex_path/.codex-plugin/plugin.json"
+    [ -f "$codex_manifest" ] || fail "Codex manifestが無い: $name"
+    if [ -f "$codex_manifest" ]; then
+      [ "$(jq -r .name "$codex_manifest" 2>/dev/null)" = "$name" ] || fail "Codex manifest name不一致: $name"
+      if [ "$(jq -r .version "$claude_manifest" 2>/dev/null)" != "$(jq -r .version "$codex_manifest" 2>/dev/null)" ]; then
+        fail "version不一致: $name"
+      fi
+      if [ "$(jq -r '.skills // empty' "$codex_manifest" 2>/dev/null)" = "./skills/" ]; then
+        [ "${#skills[@]}" -gt 0 ] || fail "検査対象skillが0件: $name"
+      fi
+    fi
+    mapfile -t codex_skill_names < <(collect_skill_names "$codex_path")
+    # Claude/Codex source pathが現状同じでも、marketplaceがhost別に分岐した時点で両集合のdriftを検出する。
+    if [ "$(printf '%s\n' "${claude_skill_names[@]}")" != "$(printf '%s\n' "${codex_skill_names[@]}")" ]; then
+      fail "skill集合不一致: $name"
+    fi
   fi
 done
 

--- a/scripts/validate-plugin-manifests.sh
+++ b/scripts/validate-plugin-manifests.sh
@@ -5,9 +5,31 @@ set -euo pipefail
 root="${1:?usage: validate-plugin-manifests.sh <repo-root>}"
 claude_marketplace="$root/.claude-plugin/marketplace.json"
 codex_marketplace="$root/.agents/plugins/marketplace.json"
+compatibility="$root/docs/references/cross-host-compatibility.json"
 errors=0
 all_skill_names=()
 fail() { printf '%s\n' "$1"; errors=$((errors + 1)); }
+
+surface_specific_codex_plugins=()
+surface_specific_claude_plugins=()
+if [ -f "$compatibility" ] && jq empty "$compatibility" >/dev/null 2>&1; then
+  mapfile -t surface_specific_codex_plugins < <(jq -r '.[]? | select(.plugin? != null and .codexLevel == "surface-specific") | .plugin' "$compatibility")
+  mapfile -t surface_specific_claude_plugins < <(jq -r '.[]? | select(.plugin? != null and .claudeLevel == "surface-specific") | .plugin' "$compatibility")
+fi
+
+declared_surface_specific() {
+  local host="$1" name="$2" plugin
+  local -n plugins
+  if [ "$host" = codex ]; then
+    plugins=surface_specific_codex_plugins
+  else
+    plugins=surface_specific_claude_plugins
+  fi
+  for plugin in "${plugins[@]}"; do
+    [ "$plugin" = "$name" ] && return 0
+  done
+  return 1
+}
 
 for file in "$claude_marketplace" "$codex_marketplace"; do
   if ! jq empty "$file" >/dev/null 2>&1; then fail "JSON不正: ${file#$root/}"; fi
@@ -20,13 +42,20 @@ mapfile -t codex_names < <(jq -r '.plugins[]?.name // empty' "$codex_marketplace
 [ "${#codex_names[@]}" -gt 0 ] || fail "Codex marketplaceの対象pluginが0件"
 
 for name in "${claude_names[@]}"; do
-  printf '%s\n' "${codex_names[@]}" | grep -Fxq "$name" || fail "Codex marketplaceに無い: $name"
+  printf '%s\n' "${codex_names[@]}" | grep -Fxq "$name" || {
+    declared_surface_specific codex "$name" || fail "Codex marketplaceに無い: $name"
+  }
 done
 for name in "${codex_names[@]}"; do
-  printf '%s\n' "${claude_names[@]}" | grep -Fxq "$name" || fail "Claude marketplaceに無い: $name"
+  printf '%s\n' "${claude_names[@]}" | grep -Fxq "$name" || {
+    declared_surface_specific claude "$name" || fail "Claude marketplaceに無い: $name"
+  }
 done
 
 for name in "${claude_names[@]}"; do
+  if ! printf '%s\n' "${codex_names[@]}" | grep -Fxq "$name"; then
+    declared_surface_specific codex "$name" && continue
+  fi
   claude_path="$root/$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source' "$claude_marketplace")"
   codex_path="$root/$(jq -r --arg n "$name" '.plugins[] | select(.name == $n) | .source.path' "$codex_marketplace")"
   [ -d "$claude_path" ] || fail "Claude source pathが無い: $name"


### PR DESCRIPTION
## Summary

- Remove `growth` from the Codex marketplace and local Codex runner installation targets.
- Declare the host-specific distribution boundary in the cross-host compatibility matrix.
- Allow only matrix-declared host-specific marketplace omissions, with bidirectional regression coverage.

## 対応 Issue AC

- [x] 1. Codex marketplaceに `growth` が存在しない
- [x] 2. Codex runnerが `growth` を導入しない
- [x] 3. compatibility matrixに `growth` / `codexLevel: surface-specific` / 非空 `residualRisk` を宣言
- [x] 4. `validate-plugin-manifests.sh` が成功
- [x] 5. 未宣言の片側欠落をplugin名付きで検出
- [x] 6. 宣言済みの片側欠落を許容
- [x] 7. 全テストスイートが成功

## セルフレビュー実施済み

- 周回数: 4
- 修正ブロッカー数: 2（片host欠落判定の双方向対応、Claude側検査維持）
- 独立レビュー: Critical/Importantなし（Minor提案はAC外の対称負例追加のため未対応）

### 修正した指摘

| 重大度 | 指摘 | 対応内容 | コミット |
|---|---|---|---|
| Important | Claude側plugin欠落をsurface-specific宣言で許容できない | matrix宣言に基づく双方向の欠落許容と回帰テストを追加 | `0435b13` |
| Important | 免除時にClaude側のmanifest/README/skill検査まで飛ばしていた | Claude側検査を常時実行し、Codex側検査だけを条件付きに分離。未宣言Claude側欠落の負例を追加 | `2431da8` |
| Important | 免除時のClaude側検査が退行しても検出できない | Claude source path検査を固定する回帰テストを追加 | `1ecc78d` |

## Verification

```text
171 tests, 0 failures
6 suites passed
```
